### PR TITLE
fix: always run inventory web

### DIFF
--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -76,7 +76,7 @@
   become: true
   roles:
     - role: ethpandaops.general.ethereum_inventory_web
-      tags: [eth_inventory_web, ethereum_inventory_web]
+      tags: [ethereum, ethereum_node, eth_inventory_web, ethereum_inventory_web]
 
 - hosts: dora
   become: true


### PR DESCRIPTION
Every time I run ethereum tag, I forget to update the inventory. WIth this, I would make sure to always re-run the inventory creation whenever I re-run the tag `ethereum`