### PR TITLE
ignore lint error

### DIFF
--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -82,8 +82,8 @@
       delegate_to: bootnode-1
       run_once: true
       vars:
-        eth_inventory_web_container_networks: "{{ docker_networks_shared }}"
-        eth_inventory_web_container_env:
+        eth_inventory_web_container_networks: "{{ docker_networks_shared }}" # noqa var-naming[no-role-prefix]
+        eth_inventory_web_container_env: # noqa var-naming[no-role-prefix]
           VIRTUAL_HOST: "bootnode-1.{{ network_subdomain }}"
           VIRTUAL_PORT: "80"
           VIRTUAL_PATH: "/meta/api"


### PR DESCRIPTION
To ignore the following:

```
WARNING  Listing 2 violation(s) that are fatal
var-naming[no-role-prefix]: Variables names from within roles should use ethereum_inventory_web_ as a prefix. (vars: eth_inventory_web_container_env)
playbook.yaml:85 Task/Handler: Refresh inventory web

var-naming[no-role-prefix]: Variables names from within roles should use ethereum_inventory_web_ as a prefix. (vars: eth_inventory_web_container_networks)
playbook.yaml:85 Task/Handler: Refresh inventory web
```