### PR TITLE
asdf: update/cleanup tools and fix missing plugins

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,9 +1,7 @@
 age 1.1.1
 helm 3.12.1
-shellcheck 0.9.0
+shellcheck 0.10.0
 sops 3.7.3
 terraform 1.6.4
-python 3.11.4
-ansible-lint 6.17.2
-awscli 2.13.7
+python 3.12.4
 yq 4.35.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-PyYAML==6.0.1
-passlib==1.7.4
 ansible-lint==24.6.0
 ansible==10.1.0
 molecule-containers==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
-ansible-lint==6.17.2
-ansible==8.2.0
-netaddr==0.8.0
-pip==23.3.1
 PyYAML==6.0.1
 passlib==1.7.4
+ansible-lint==24.6.0
+ansible==10.1.0
+molecule-containers==2.0.0
+molecule==24.6.0
+netaddr==1.3.0
+pip==24.0
+requests==2.31 # Fix for not being able to run 'molecule test' using docker on mac. Issue: https://github.com/docker/docker-py/issues/3256

--- a/setup.sh
+++ b/setup.sh
@@ -7,6 +7,7 @@ asdf plugin add sops https://github.com/feniix/asdf-sops.git
 asdf plugin add terraform https://github.com/asdf-community/asdf-hashicorp.git
 asdf plugin-add helm https://github.com/Antiarchitect/asdf-helm.git
 asdf plugin-add python
+asdf plugin-add yq https://github.com/sudermanjr/asdf-yq.git
 
 asdf install
 


### PR DESCRIPTION
- Add `yq` asdf plugin
- Remove `awscli` from asdf. 
- Get rid of asdf installed ansible-lint, this is already installed via python/pip requirements.txt

fixes https://github.com/ethpandaops/template-devnets/issues/55