### PR TITLE
grandine: default to bigger log retention for docker containers

### DIFF
--- a/ansible/inventories/devnet-0/group_vars/grandine.yaml
+++ b/ansible/inventories/devnet-0/group_vars/grandine.yaml
@@ -3,7 +3,14 @@ bootstrap_default_user_authorized_keys_github_team_cl:
   - sauliusgrigaitis
   - tumas
   - povi
-  
+
+# role: geerlingguy.docker
+docker_daemon_options:
+  "log-driver": "json-file"
+  "log-opts":
+      "max-size": "500m"
+      "max-file": "40"
+
 # role: validator_keys
 validator_keys_sync_files:
   - src: "{{ inventory_dir }}/files/validator_keys/{{ inventory_hostname }}/teku-keys/"


### PR DESCRIPTION
not sure if this is the right approach since it might fill the disk quicker.