### PR TITLE
remove ansible-lint from  .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -3,7 +3,6 @@ helm 3.15.3
 sops 3.8.1
 shellcheck 0.10.0
 python 3.12.4
-ansible-lint 6.17.2
 awscli 2.22.26
 yq 4.44.6
 terraform 1.9.0

--- a/setup.sh
+++ b/setup.sh
@@ -8,6 +8,7 @@ asdf plugin add terraform https://github.com/asdf-community/asdf-hashicorp.git |
 asdf plugin-add helm https://github.com/Antiarchitect/asdf-helm.git || true
 asdf plugin-add python || true
 asdf plugin-add yq https://github.com/sudermanjr/asdf-yq.git || true
+asdf plugin add awscli || true
 
 asdf install
 


### PR DESCRIPTION
ansible-lint should be installed via pip