### PR TITLE
refactor: Remove default pp img.

### DIFF
--- a/ansible/inventories/devnet-0/group_vars/all/images.yaml
+++ b/ansible/inventories/devnet-0/group_vars/all/images.yaml
@@ -52,4 +52,3 @@ default_tooling_images:
   nginx_proxy_gen: docker.ethquokkaops.io/dh/nginxproxy/docker-gen
   nginx_proxy_acme: docker.ethquokkaops.io/dh/nginxproxy/acme-companion
   vector: docker.ethquokkaops.io/dh/timberio/vector:0.30.0-alpine
-  panda_pulse: docker.ethquokkaops.io/dh/ethpandaops/panda-pulse:0.0.10


### PR DESCRIPTION
- Removed from default panda-pulse img used in devnet templates
- Panda pulse templated crons within devnets being superseded by platform application.

