### PR TITLE
Add missing xatu_mimicry entries

### DIFF
--- a/ansible/inventories/devnet-0/group_vars/all/images.yaml
+++ b/ansible/inventories/devnet-0/group_vars/all/images.yaml
@@ -21,6 +21,8 @@ default_tooling_images:
   mev_boost_relay: docker.ethquokkaops.io/dh/ethpandaops/mev-boost-relay:latest
   xatu_sentry: docker.ethquokkaops.io/dh/ethpandaops/xatu:latest
   xatu_cannon: docker.ethquokkaops.io/dh/ethpandaops/xatu:latest
+  xatu_mimicry: docker.ethquokkaops.io/dh/ethpandaops/xatu:latest
+  xatu_cl_mimicry: docker.ethquokkaops.io/dh/ethpandaops/xatu:latest
   ethereum_metrics_exporter: docker.ethquokkaops.io/dh/ethpandaops/ethereum-metrics-exporter:latest
   tx_fuzz: docker.ethquokkaops.io/dh/ethpandaops/tx-fuzz:latest
   forkmon: docker.ethquokkaops.io/dh/skylenet/nodemonitor:darkmode


### PR DESCRIPTION
`xatu_mimicry` and `xatu_cl_mimicry` images were not defined in template leading to missing attribute error.

```
TASK [ethpandaops.general.generate_kubernetes_config : Generate values file for xatu-mimicry] ***************************************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.errors.AnsibleUndefinedVariable: 'dict object' has no attribute 'xatu_mimicry'
fatal: [localhost]: FAILED! => changed=false
  msg: 'AnsibleUndefinedVariable: ''dict object'' has no attribute ''xatu_mimicry'''
```