### PR TITLE
fix plugin-add typo

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe 
+#!/bin/bash -xe
 
 # Uninstall previous asdf plugins that shouldn't be managed anymore under asdf
 asdf uninstall ansible || true
@@ -9,9 +9,9 @@ asdf plugin add age https://github.com/threkk/asdf-age.git || true
 asdf plugin add shellcheck https://github.com/luizm/asdf-shellcheck.git || true
 asdf plugin add sops https://github.com/feniix/asdf-sops.git || true
 asdf plugin add terraform https://github.com/asdf-community/asdf-hashicorp.git || true
-asdf plugin-add helm https://github.com/Antiarchitect/asdf-helm.git || true
-asdf plugin-add python || true
-asdf plugin-add yq https://github.com/sudermanjr/asdf-yq.git || true
+asdf plugin add helm https://github.com/Antiarchitect/asdf-helm.git || true
+asdf plugin add python || true
+asdf plugin add yq https://github.com/sudermanjr/asdf-yq.git || true
 asdf plugin add awscli || true
 
 asdf install


### PR DESCRIPTION
My new version of asdf `0.18.0` does not support the plugin-add alias. The go rewrite I assume removed this alias in newer versions.