### PR TITLE
Update besu repo reference to besu-eth/besu

### DIFF
--- a/.github/workflows/syncoor-devnet-0.yaml
+++ b/.github/workflows/syncoor-devnet-0.yaml
@@ -49,11 +49,11 @@ on:
         default: ''
         type: string
       el-image:
-        description: 'Execution layer client images as JSON (e.g., {"geth": "ethereum/client-go:latest", "besu": "hyperledger/besu:latest"})'
+        description: 'Execution layer client images as JSON (e.g., {"geth": "ethereum/client-go:latest", "besu": "besu-eth/besu:latest"})'
         required: false
         default: >-
           {
-            "besu": "hyperledger/besu:latest",
+            "besu": "besu-eth/besu:latest",
             "geth": "ethereum/client-go:stable",
             "erigon": "erigontech/erigon:latest",
             "nethermind": "nethermind/nethermind:latest",
@@ -138,7 +138,7 @@ jobs:
       run: |
         cat > /tmp/default-el-images.json <<'EOF'
         {
-          "besu": "hyperledger/besu:latest",
+          "besu": "besu-eth/besu:latest",
           "geth": "ethereum/client-go:stable",
           "erigon": "erigontech/erigon:latest",
           "nethermind": "nethermind/nethermind:latest",

--- a/ansible/inventories/devnet-0/group_vars/all/images.yaml
+++ b/ansible/inventories/devnet-0/group_vars/all/images.yaml
@@ -8,7 +8,7 @@ default_ethereum_client_images:
   teku: consensys/teku:latest
   grandine: ethpandaops/grandine:develop
   ### Execution layer clients
-  besu: hyperledger/besu:latest
+  besu: besu-eth/besu:latest
   geth: ethereum/client-go:stable
   erigon: erigontech/erigon:main-latest
   nethermind: nethermindeth/nethermind:master


### PR DESCRIPTION
## Summary
- Update all references from `hyperledger/besu` to `besu-eth/besu` to reflect the repository migration

## Test plan
- [ ] Verify CI workflows still resolve the correct besu images/repos