### PR TITLE
fix: derive inventory path from ethereum_network variable

### DIFF
--- a/terraform/devnet-0/outputs.tf
+++ b/terraform/devnet-0/outputs.tf
@@ -44,7 +44,7 @@ resource "local_file" "ansible_inventory" {
       )
     }
   )
-  filename = "../../ansible/inventories/devnet-0/inventory.ini"
+  filename = "../../ansible/inventories/${join("-", slice(split("-", var.ethereum_network), length(split("-", var.ethereum_network)) - 2, length(split("-", var.ethereum_network))))}/inventory.ini"
 }
 
 locals {


### PR DESCRIPTION
## Summary
- Replaces hardcoded `devnet-0` in the inventory filename with an expression that extracts the last two dash-separated parts from `var.ethereum_network` (e.g. `epbs-devnet-1` → `devnet-1`)
- Prevents the inventory path from getting out of sync when only `var.ethereum_network` is updated

## Test plan
- [ ] Verify `terraform plan` shows no unexpected changes on an existing devnet
- [ ] Confirm the generated inventory file lands in the correct path

🤖 Generated with [Claude Code](https://claude.com/claude-code)