### PR TITLE
ci: bump pinned GitHub Actions to latest

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: Install asdf
-      uses: asdf-vm/actions/setup@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # v3.0.2
+      uses: asdf-vm/actions/setup@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
 
     - name: Install asdf tools
       shell: bash

--- a/.github/workflows/hive-devnet-0.yaml.no_run
+++ b/.github/workflows/hive-devnet-0.yaml.no_run
@@ -115,7 +115,7 @@ jobs:
           steps.client_config_dispatch.outputs.client_config
         }}
     steps:
-      - uses: ethpandaops/hive-github-action/helpers/client-config@a9ec89442df18ee579d3179b76c47f5f93954307 # v0.4.0
+      - uses: ethpandaops/hive-github-action/helpers/client-config@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
         if: github.event_name == 'schedule'
         name: 'Client config: schedule'
         id: client_config_schedule
@@ -125,7 +125,7 @@ jobs:
           hive_version: 'ethereum/hive@master'
           goproxy: ${{ env.GOPROXY }}
 
-      - uses: ethpandaops/hive-github-action/helpers/client-config@a9ec89442df18ee579d3179b76c47f5f93954307 # v0.4.0
+      - uses: ethpandaops/hive-github-action/helpers/client-config@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
         if: github.event_name == 'workflow_dispatch'
         name: 'Client config: workflow_dispatch'
         id: client_config_dispatch
@@ -168,14 +168,14 @@ jobs:
             "ethereum/eest/consume-rlp"
           '))}}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ethpandaops/hive-github-action/helpers/self-hosted-runner-dependencies@a9ec89442df18ee579d3179b76c47f5f93954307 # v0.4.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ethpandaops/hive-github-action/helpers/self-hosted-runner-dependencies@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
         if: runner.environment != 'github-hosted'
-      - uses: ethpandaops/actions/docker-login@a91b7a8dd6a264f5e845ac2aa52d2d6f24e6d01d
+      - uses: ethpandaops/actions/docker-login@99b48ca2b233a2eff93e6a6df76e46b718aca108
         with:
           username: ethpandaops
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: ethpandaops/hive-github-action@a9ec89442df18ee579d3179b76c47f5f93954307 # v0.4.0
+      - uses: ethpandaops/hive-github-action@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
         with:
           hive_repository: ${{ needs.prepare.outputs.hive_repo }}
           hive_version: ${{ needs.prepare.outputs.hive_tag }}

--- a/.github/workflows/syncoor-devnet-0.yaml
+++ b/.github/workflows/syncoor-devnet-0.yaml
@@ -248,7 +248,7 @@ jobs:
         git-ref: ${{ inputs.git-ref }}
 
     - name: Update test results index
-      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |

--- a/terraform/devnet-0/digitalocean.tf
+++ b/terraform/devnet-0/digitalocean.tf
@@ -59,7 +59,7 @@ locals {
           "${i + 1}" = {
             # Validator range for this instance
             val_start = node.validator_start + (i * (node.validator_end - node.validator_start) / node.count)
-            val_end   = min(
+            val_end = min(
               node.validator_start + ((i + 1) * (node.validator_end - node.validator_start) / node.count),
               node.validator_end
             )
@@ -115,9 +115,9 @@ locals {
           "val_end:${vm.val_end}",
           "supernode:${vm.supernode ? "True" : "False"}",
           "arch:${vm.arch}",
-        ], compact([
-          can(regex("bootnode", group.group_name)) ? "bootnode:${var.ethereum_network}" : null,
-          can(regex("mev-relay", group.group_name)) ? "mev-relay:${var.ethereum_network}" : null
+          ], compact([
+            can(regex("bootnode", group.group_name)) ? "bootnode:${var.ethereum_network}" : null,
+            can(regex("mev-relay", group.group_name)) ? "mev-relay:${var.ethereum_network}" : null
         ]))
       }
     ]

--- a/terraform/devnet-0/hetzner.tf
+++ b/terraform/devnet-0/hetzner.tf
@@ -54,7 +54,7 @@ locals {
           "${i + 1}" = {
             # Validator range for this instance
             val_start = node.validator_start + (i * (node.validator_end - node.validator_start) / node.count)
-            val_end   = min(
+            val_end = min(
               node.validator_start + ((i + 1) * (node.validator_end - node.validator_start) / node.count),
               node.validator_end
             )
@@ -120,9 +120,9 @@ locals {
           "val_end:${vm.val_end}",
           "supernode:${vm.supernode ? "True" : "False"}",
           "arch:${can(regex("^cax", vm.size)) ? "arm64" : "amd64"}",
-        ], compact([
-          can(regex("bootnode", group.group_name)) ? "bootnode:${var.ethereum_network}" : null,
-          can(regex("mev-relay", group.group_name)) ? "mev:${var.ethereum_network}" : null
+          ], compact([
+            can(regex("bootnode", group.group_name)) ? "bootnode:${var.ethereum_network}" : null,
+            can(regex("mev-relay", group.group_name)) ? "mev:${var.ethereum_network}" : null
         ]))
       }
     ]


### PR DESCRIPTION
## Summary

Bumps all outdated pinned GitHub Actions to their latest versions. The `asdf-vm/actions/setup` bump is the load-bearing one — v3.0.2 silently broke recently because it clones asdf from `master`, which after the asdf v0.16 Go rewrite no longer leaves a usable `asdf` binary on PATH. v4.x installs the Go binary directly.

| Action | Old | New |
|---|---|---|
| `asdf-vm/actions/setup` | v3.0.2 | v4.0.1 |
| `actions/github-script` | v8.0.0 | v9.0.0 |
| `ethpandaops/hive-github-action` (+ helpers) | v0.4.0 | v0.6.3 |
| `actions/checkout` (in `.no_run`) | v4.2.2 | v6.0.2 |
| `ethpandaops/actions/docker-login` | old SHA | master SHA `99b48ca` |

The hive / checkout / docker-login changes are inside `hive-devnet-0.yaml.no_run`, which isn't active — they're housekeeping so the template stays current when downstream devnets copy it.

## Test plan

- [ ] Lint workflows (`ansible-lint`, `helm-lint`, `terraform-lint`) run green on this PR — confirms the asdf v4 setup works against the current `.tool-versions`.
- [ ] `syncoor-devnet-0.yaml` / `syncoor-generate-index.yaml` — no direct CI here, verified syntactically only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)