### PR TITLE
rework ipv6 setup

### DIFF
--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -18,9 +18,6 @@ service_ipv6_offsets:
   snooper_rpc: 12     # :c
   beacon: 11          # :b
   validator: 10       # :a
-  mev_boost: 9        # :9
-  xatu_sentry: 8      # :8
-  metrics_exporter: 7 # :7
 
 # Derive host IPv6 prefix from the Terraform-provided `ipv6` host var.
 # Hetzner gives a /64, DO gives a /124.

--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -62,7 +62,8 @@ docker_network_driver_options: >-
   {{ {'com.docker.network.bridge.gateway_mode_ipv6': 'routed'}
      if (docker_network_enable_ipv6 | bool) else {} }}
 docker_network_ipam_config: >-
-  {{ [{'subnet': host_ipv6_prefix, 'gateway': host_ipv6_prefix | ansible.utils.ipaddr(2) | ansible.utils.ipaddr('address')}]
+  {{ [{'subnet': host_ipv6_prefix,
+       'gateway': host_ipv6_prefix | ansible.utils.ipaddr(1) | ansible.utils.ipaddr('address')}]
      if (docker_network_enable_ipv6 | bool) else [] }}
 docker_network_ipv6_pool: >-
   {{ (host_ipv6_prefix | ansible.utils.ipsubnet(124, 0))

--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -7,9 +7,22 @@ devnet_name: template
 
 # IPv6 Specific configuration
 global_ipv6_enabled: true
-global_ipv6_subnet_ranges:
-  hetzner: "64"
-  digitalocean: "124"
+
+# Per-service IPv6 offset within the host's assigned prefix.
+# DO /124 has only ::3..::f usable, so offsets must stay small.
+# Use end of range for static assignments, start will be auto assigned to remaining containers.
+service_ipv6_offsets:
+  nginx_proxy: 15    # :f
+  execution: 14      # :e (execution)
+  snooper_engine: 13 # :d
+  snooper_rpc: 12    # :c
+  consensus: 11      # :b (beacon)
+  validator: 10      # :a
+
+# Derive host IPv6 prefix from the Terraform-provided `ipv6` host var.
+# Hetzner gives a /64, DO gives a /124.
+host_ipv6_prefix_length: "{{ '64' if cloud | default('') == 'hetzner' else '124' }}"
+host_ipv6_prefix: "{{ (ipv6 | default('')) | ansible.utils.ipsubnet(host_ipv6_prefix_length | int) if (ipv6 | default('')) | length > 0 else '' }}"
 
 ######################################################
 ##
@@ -41,12 +54,16 @@ fail2ban_ignoreips:
 
 # role: ethpandaops.general.docker_network
 docker_network_name: shared
-docker_network_enable_ipv6: "{{ global_ipv6_enabled }}"
+docker_network_enable_ipv6: "{{ global_ipv6_enabled | default(false) | bool and (host_ipv6_prefix | default('') | length > 0) }}"
+docker_network_driver_options: >-
+  {{ {'com.docker.network.bridge.gateway_mode_ipv6': 'routed'}
+     if (docker_network_enable_ipv6 | bool) else {} }}
 docker_network_ipam_config: >-
-  {{ global_ipv6_enabled | default(false) | ternary(
-    [ { 'subnet': ansible_default_ipv6.address | default('::1') | ansible.utils.ipsubnet(global_ipv6_subnet_ranges[hostvars[inventory_hostname]['cloud']]) } ]
-    , [])
-  }}
+  {{ [{'subnet': host_ipv6_prefix, 'gateway': host_ipv6_prefix | ansible.utils.ipaddr(2) | ansible.utils.ipaddr('address')}]
+     if (docker_network_enable_ipv6 | bool) else [] }}
+docker_network_ipv6_pool: >-
+  {{ (host_ipv6_prefix | ansible.utils.ipsubnet(124, 0))
+     if (docker_network_enable_ipv6 | bool) else '' }}
 
 docker_networks_shared:
   - name: "{{ docker_network_name }}"

--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -13,10 +13,10 @@ global_ipv6_enabled: true
 # Use end of range for static assignments, start will be auto assigned to remaining containers.
 service_ipv6_offsets:
   nginx_proxy: 15    # :f
-  execution: 14      # :e (execution)
+  execution: 14      # :e
   snooper_engine: 13 # :d
   snooper_rpc: 12    # :c
-  consensus: 11      # :b (beacon)
+  beacon: 11         # :b
   validator: 10      # :a
 
 # Derive host IPv6 prefix from the Terraform-provided `ipv6` host var.

--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -12,12 +12,15 @@ global_ipv6_enabled: true
 # DO /124 has only ::3..::f usable, so offsets must stay small.
 # Use end of range for static assignments, start will be auto assigned to remaining containers.
 service_ipv6_offsets:
-  nginx_proxy: 15    # :f
-  execution: 14      # :e
-  snooper_engine: 13 # :d
-  snooper_rpc: 12    # :c
-  beacon: 11         # :b
-  validator: 10      # :a
+  nginx_proxy: 15     # :f
+  execution: 14       # :e
+  snooper_engine: 13  # :d
+  snooper_rpc: 12     # :c
+  beacon: 11          # :b
+  validator: 10       # :a
+  mev_boost: 9        # :9
+  xatu_sentry: 8      # :8
+  metrics_exporter: 7 # :7
 
 # Derive host IPv6 prefix from the Terraform-provided `ipv6` host var.
 # Hetzner gives a /64, DO gives a /124.

--- a/ansible/inventories/devnet-0/group_vars/all/all.yaml
+++ b/ansible/inventories/devnet-0/group_vars/all/all.yaml
@@ -254,7 +254,7 @@ docker_nginx_proxy_acme_companion_container_env:
   ACME_EAB_HMAC_KEY: "{{ secret_zerossl.ACME_EAB_HMAC_KEY }}"
 docker_nginx_proxy_container_networks: >-
   {{ [{'name': 'shared'} | combine({'ipv6_address': docker_nginx_proxy_public_ipv6} if (docker_nginx_proxy_public_ipv6 | default('') | length > 0) else {})] }}
-docker_nginx_proxy_docker_gen_container_networks: "{{ docker_networks_shared }}"
+docker_nginx_proxy_docker_gen_container_networks: []
 docker_nginx_proxy_acme_companion_container_networks: "{{ docker_networks_shared }}"
 docker_nginx_proxy_acme_monitor_container_networks: "{{ docker_networks_shared }}"
 docker_nginx_proxy_acme_monitor_enabled: false
@@ -267,8 +267,8 @@ docker_nginx_proxy_container_volumes:
   - "{{ docker_nginx_proxy_datadir }}/htpasswd:/etc/nginx/htpasswd:ro"
 docker_nginx_proxy_cert_loader_container_image: "{{ default_tooling_images.nginx_proxy_cert_loader }}"
 docker_nginx_proxy_cert_linker_container_image: "{{ default_tooling_images.nginx_proxy_cert_linker }}"
-docker_nginx_proxy_cert_loader_container_networks: "{{ docker_networks_shared }}"
-docker_nginx_proxy_cert_linker_container_networks: "{{ docker_networks_shared }}"
+docker_nginx_proxy_cert_loader_container_networks: []
+docker_nginx_proxy_cert_linker_container_networks: []
 docker_nginx_proxy_wildcard_cert: "{{ network_server_subdomain }}"
 docker_nginx_proxy_wildcard_cert_url: "http://cert.{{ network_server_subdomain }}/{{ network_server_subdomain }}-latest.tar.enc"
 docker_nginx_proxy_wildcard_cert_psk: "{{ secret_cert_encryption_psk }}"

--- a/ansible/inventories/devnet-0/group_vars/all/all.yaml
+++ b/ansible/inventories/devnet-0/group_vars/all/all.yaml
@@ -139,9 +139,6 @@ ethereum_node_cl_public_ipv6: "{{ host_ipv6_prefix | ansible.utils.ipaddr(servic
 ethereum_node_validator_public_ipv6: "{{ host_ipv6_prefix | ansible.utils.ipaddr(service_ipv6_offsets.validator) | ansible.utils.ipaddr('address') if (docker_network_enable_ipv6 | bool) else '' }}"
 ethereum_node_snooper_rpc_public_ipv6: "{{ host_ipv6_prefix | ansible.utils.ipaddr(service_ipv6_offsets.snooper_rpc) | ansible.utils.ipaddr('address') if (docker_network_enable_ipv6 | bool) else '' }}"
 ethereum_node_snooper_engine_public_ipv6: "{{ host_ipv6_prefix | ansible.utils.ipaddr(service_ipv6_offsets.snooper_engine) | ansible.utils.ipaddr('address') if (docker_network_enable_ipv6 | bool) else '' }}"
-ethereum_node_mev_boost_public_ipv6: "{{ host_ipv6_prefix | ansible.utils.ipaddr(service_ipv6_offsets.mev_boost) | ansible.utils.ipaddr('address') if (docker_network_enable_ipv6 | bool) else '' }}"
-ethereum_node_xatu_sentry_public_ipv6: "{{ host_ipv6_prefix | ansible.utils.ipaddr(service_ipv6_offsets.xatu_sentry) | ansible.utils.ipaddr('address') if (docker_network_enable_ipv6 | bool) else '' }}"
-ethereum_node_metrics_exporter_public_ipv6: "{{ host_ipv6_prefix | ansible.utils.ipaddr(service_ipv6_offsets.metrics_exporter) | ansible.utils.ipaddr('address') if (docker_network_enable_ipv6 | bool) else '' }}"
 ethereum_node_skip_cleanup: true
 ethereum_node_docker_watchtower_enabled: true
 ethereum_node_docker_watchtower_containers_list:

--- a/ansible/inventories/devnet-0/group_vars/all/all.yaml
+++ b/ansible/inventories/devnet-0/group_vars/all/all.yaml
@@ -135,7 +135,7 @@ ethereum_node_el_ports_engine: 8551
 ethereum_node_el_ports_metrics: 6060
 ethereum_node_ipv6_enabled: true
 ethereum_node_el_public_ipv6: "{{ host_ipv6_prefix | ansible.utils.ipaddr(service_ipv6_offsets.execution) | ansible.utils.ipaddr('address') if (docker_network_enable_ipv6 | bool) else '' }}"
-ethereum_node_cl_public_ipv6: "{{ host_ipv6_prefix | ansible.utils.ipaddr(service_ipv6_offsets.consensus) | ansible.utils.ipaddr('address') if (docker_network_enable_ipv6 | bool) else '' }}"
+ethereum_node_cl_public_ipv6: "{{ host_ipv6_prefix | ansible.utils.ipaddr(service_ipv6_offsets.beacon) | ansible.utils.ipaddr('address') if (docker_network_enable_ipv6 | bool) else '' }}"
 ethereum_node_validator_public_ipv6: "{{ host_ipv6_prefix | ansible.utils.ipaddr(service_ipv6_offsets.validator) | ansible.utils.ipaddr('address') if (docker_network_enable_ipv6 | bool) else '' }}"
 ethereum_node_snooper_rpc_public_ipv6: "{{ host_ipv6_prefix | ansible.utils.ipaddr(service_ipv6_offsets.snooper_rpc) | ansible.utils.ipaddr('address') if (docker_network_enable_ipv6 | bool) else '' }}"
 ethereum_node_snooper_engine_public_ipv6: "{{ host_ipv6_prefix | ansible.utils.ipaddr(service_ipv6_offsets.snooper_engine) | ansible.utils.ipaddr('address') if (docker_network_enable_ipv6 | bool) else '' }}"

--- a/ansible/inventories/devnet-0/group_vars/all/all.yaml
+++ b/ansible/inventories/devnet-0/group_vars/all/all.yaml
@@ -134,6 +134,11 @@ ethereum_node_el_ports_ws_rpc: 8546
 ethereum_node_el_ports_engine: 8551
 ethereum_node_el_ports_metrics: 6060
 ethereum_node_ipv6_enabled: true
+ethereum_node_el_public_ipv6: "{{ host_ipv6_prefix | ansible.utils.ipaddr(service_ipv6_offsets.execution) | ansible.utils.ipaddr('address') if (docker_network_enable_ipv6 | bool) else '' }}"
+ethereum_node_cl_public_ipv6: "{{ host_ipv6_prefix | ansible.utils.ipaddr(service_ipv6_offsets.consensus) | ansible.utils.ipaddr('address') if (docker_network_enable_ipv6 | bool) else '' }}"
+ethereum_node_validator_public_ipv6: "{{ host_ipv6_prefix | ansible.utils.ipaddr(service_ipv6_offsets.validator) | ansible.utils.ipaddr('address') if (docker_network_enable_ipv6 | bool) else '' }}"
+ethereum_node_snooper_rpc_public_ipv6: "{{ host_ipv6_prefix | ansible.utils.ipaddr(service_ipv6_offsets.snooper_rpc) | ansible.utils.ipaddr('address') if (docker_network_enable_ipv6 | bool) else '' }}"
+ethereum_node_snooper_engine_public_ipv6: "{{ host_ipv6_prefix | ansible.utils.ipaddr(service_ipv6_offsets.snooper_engine) | ansible.utils.ipaddr('address') if (docker_network_enable_ipv6 | bool) else '' }}"
 ethereum_node_skip_cleanup: true
 ethereum_node_docker_watchtower_enabled: true
 ethereum_node_docker_watchtower_containers_list:
@@ -231,11 +236,13 @@ docker_nginx_proxy_docker_gen_container_image: "{{ default_tooling_images.nginx_
 docker_nginx_proxy_acme_companion_container_image: "{{ default_tooling_images.nginx_proxy_acme }}"
 
 # role: ethpandaops.general.docker_nginx_proxy
+docker_nginx_proxy_public_ipv6: "{{ host_ipv6_prefix | ansible.utils.ipaddr(service_ipv6_offsets.nginx_proxy) | ansible.utils.ipaddr('address') if (docker_network_enable_ipv6 | bool) else '' }}"
 docker_nginx_proxy_container_name: nginx-proxy
 docker_nginx_proxy_default_email: "certs@{{ domain }}"
 docker_nginx_proxy_docker_gen_container_name: nginx-proxy-gen
 docker_nginx_proxy_docker_gen_container_env:
   RESOLVERS: "1.1.1.1"
+  ENABLE_IPV6: "true"
 docker_nginx_proxy_acme_companion_enabled: false
 docker_nginx_proxy_acme_companion_container_name: nginx-proxy-acme
 docker_nginx_proxy_acme_companion_container_env:
@@ -245,7 +252,8 @@ docker_nginx_proxy_acme_companion_container_env:
   ACME_CA_URI: https://acme.zerossl.com/v2/DV90
   ACME_EAB_KID: "{{ secret_zerossl.ACME_EAB_KID }}"
   ACME_EAB_HMAC_KEY: "{{ secret_zerossl.ACME_EAB_HMAC_KEY }}"
-docker_nginx_proxy_container_networks: "{{ docker_networks_shared }}"
+docker_nginx_proxy_container_networks: >-
+  {{ [{'name': 'shared'} | combine({'ipv6_address': docker_nginx_proxy_public_ipv6} if (docker_nginx_proxy_public_ipv6 | default('') | length > 0) else {})] }}
 docker_nginx_proxy_docker_gen_container_networks: "{{ docker_networks_shared }}"
 docker_nginx_proxy_acme_companion_container_networks: "{{ docker_networks_shared }}"
 docker_nginx_proxy_acme_monitor_container_networks: "{{ docker_networks_shared }}"

--- a/ansible/inventories/devnet-0/group_vars/all/all.yaml
+++ b/ansible/inventories/devnet-0/group_vars/all/all.yaml
@@ -139,6 +139,9 @@ ethereum_node_cl_public_ipv6: "{{ host_ipv6_prefix | ansible.utils.ipaddr(servic
 ethereum_node_validator_public_ipv6: "{{ host_ipv6_prefix | ansible.utils.ipaddr(service_ipv6_offsets.validator) | ansible.utils.ipaddr('address') if (docker_network_enable_ipv6 | bool) else '' }}"
 ethereum_node_snooper_rpc_public_ipv6: "{{ host_ipv6_prefix | ansible.utils.ipaddr(service_ipv6_offsets.snooper_rpc) | ansible.utils.ipaddr('address') if (docker_network_enable_ipv6 | bool) else '' }}"
 ethereum_node_snooper_engine_public_ipv6: "{{ host_ipv6_prefix | ansible.utils.ipaddr(service_ipv6_offsets.snooper_engine) | ansible.utils.ipaddr('address') if (docker_network_enable_ipv6 | bool) else '' }}"
+ethereum_node_mev_boost_public_ipv6: "{{ host_ipv6_prefix | ansible.utils.ipaddr(service_ipv6_offsets.mev_boost) | ansible.utils.ipaddr('address') if (docker_network_enable_ipv6 | bool) else '' }}"
+ethereum_node_xatu_sentry_public_ipv6: "{{ host_ipv6_prefix | ansible.utils.ipaddr(service_ipv6_offsets.xatu_sentry) | ansible.utils.ipaddr('address') if (docker_network_enable_ipv6 | bool) else '' }}"
+ethereum_node_metrics_exporter_public_ipv6: "{{ host_ipv6_prefix | ansible.utils.ipaddr(service_ipv6_offsets.metrics_exporter) | ansible.utils.ipaddr('address') if (docker_network_enable_ipv6 | bool) else '' }}"
 ethereum_node_skip_cleanup: true
 ethereum_node_docker_watchtower_enabled: true
 ethereum_node_docker_watchtower_containers_list:

--- a/ansible/inventories/devnet-0/group_vars/dns_server.yaml
+++ b/ansible/inventories/devnet-0/group_vars/dns_server.yaml
@@ -42,8 +42,9 @@ dns_server_zones:
       bootnodoor-{{ hostvars[host]['inventory_hostname'] }}                        IN  A     {{ hostvars[host]['ansible_host'] }}
       {% if hostvars[host]['ipv6'] is defined %}
       {{ hostvars[host]['inventory_hostname'] }}                                   IN  AAAA  {{ hostvars[host]['ipv6'] }}
-      {{ ethereum_node_rpc_prefix }}{{ hostvars[host]['inventory_hostname'] }}     IN  AAAA  {{ hostvars[host]['ipv6'] }}
-      {{ ethereum_node_beacon_prefix }}{{ hostvars[host]['inventory_hostname'] }}  IN  AAAA  {{ hostvars[host]['ipv6'] }}
+      {% set proxy_ipv6 = hostvars[host].get('docker_nginx_proxy_public_ipv6', hostvars[host]['ipv6']) %}
+      {{ ethereum_node_rpc_prefix }}{{ hostvars[host]['inventory_hostname'] }}     IN  AAAA  {{ proxy_ipv6 if proxy_ipv6 | length > 0 else hostvars[host]['ipv6'] }}
+      {{ ethereum_node_beacon_prefix }}{{ hostvars[host]['inventory_hostname'] }}  IN  AAAA  {{ proxy_ipv6 if proxy_ipv6 | length > 0 else hostvars[host]['ipv6'] }}
       {% endif %}
       {% endfor %}
 
@@ -54,8 +55,9 @@ dns_server_zones:
       {{ ethereum_node_beacon_prefix }}{{ hostvars[host]['inventory_hostname'] }}  IN  A     {{ hostvars[host]['ansible_host'] }}
       {% if hostvars[host]['ipv6'] is defined %}
       {{ hostvars[host]['inventory_hostname'] }}                                   IN  AAAA  {{ hostvars[host]['ipv6'] }}
-      {{ ethereum_node_rpc_prefix }}{{ hostvars[host]['inventory_hostname'] }}     IN  AAAA  {{ hostvars[host]['ipv6'] }}
-      {{ ethereum_node_beacon_prefix }}{{ hostvars[host]['inventory_hostname'] }}  IN  AAAA  {{ hostvars[host]['ipv6'] }}
+      {% set proxy_ipv6 = hostvars[host].get('docker_nginx_proxy_public_ipv6', hostvars[host]['ipv6']) %}
+      {{ ethereum_node_rpc_prefix }}{{ hostvars[host]['inventory_hostname'] }}     IN  AAAA  {{ proxy_ipv6 if proxy_ipv6 | length > 0 else hostvars[host]['ipv6'] }}
+      {{ ethereum_node_beacon_prefix }}{{ hostvars[host]['inventory_hostname'] }}  IN  AAAA  {{ proxy_ipv6 if proxy_ipv6 | length > 0 else hostvars[host]['ipv6'] }}
       {% endif %}
       {% endfor %}
 


### PR DESCRIPTION
## Summary

Enable public IPv6 per container using the new `docker_network` IPv6 routed mode from ansible-collection-general. Each Ethereum container gets a deterministic public IPv6 address for direct P2P connectivity.

### Changes

**`ansible/group_vars/all/defaults.yaml`**
- Added `service_ipv6_offsets` mapping roles to IPv6 suffix within the host's prefix:
  - `:f` nginx-proxy, `:e` execution, `:d` snooper-engine, `:c` snooper-rpc, `:b` beacon, `:a` validator
  - Low addresses (`:0`-`:9`) left for Docker auto-assignment to infra containers
- Added `host_ipv6_prefix_length` and `host_ipv6_prefix` derivation from Terraform-provided `ipv6` host var (Hetzner `/64`, DO `/124`)
- Replaced old `docker_network_ipam_config` (which put the full prefix on a plain bridge with no routed mode) with:
  - `docker_network_enable_ipv6` / `docker_network_driver_options` (routed mode)
  - `docker_network_ipam_config` with gateway at offset `:2`
  - `docker_network_ipv6_pool` — narrow `/124` route for the container pool

**`ansible/inventories/devnet-0/group_vars/all/all.yaml`**
- Added per-role public IPv6 computation (`ethereum_node_{el,cl,validator,snooper_rpc,snooper_engine}_public_ipv6`)
- Added `docker_nginx_proxy_public_ipv6` and `ipv6_address` on the proxy's shared network entry
- Added `ENABLE_IPV6: "true"` to docker-gen env so nginx listens on `[::]:80` / `[::]:443`

**`ansible/inventories/devnet-0/group_vars/dns_server.yaml`**
- AAAA records for `rpc-*` / `bn-*` now point to the nginx-proxy's IPv6 (matching the IPv4 model where A records point to the host running the proxy)
- Base hostname AAAA stays on the host's IPv6

### Depends on

- ansible-collection-general IPv6 PR (docker_network routed mode + ndppd + client role _public_ipv6 support)

## Test plan

- [x] Deployed on pk-devnet-0 (2x DO + 1x Hetzner)
- [x] Static IPv6 addresses correctly assigned to execution (`:e`), beacon (`:b`), snooper (`:d`), nginx-proxy (`:f`)
- [x] IPv6 egress works from all containers on both providers
- [x] IPv6 ingress works for P2P ports cross-provider
- [x] HTTPS RPC/beacon endpoints reachable via nginx-proxy IPv6
- [x] IPv4 port publishing and inter-container DNS unaffected
- [x] Verify ENR contains correct container IPv6 (not host IPv6)
