### PR TITLE
chore: bump mitogen to 0.3.43

### DIFF
--- a/ansible/install_dependencies.sh
+++ b/ansible/install_dependencies.sh
@@ -4,7 +4,7 @@ ansible-galaxy install -r requirements.yaml --force
 
 # Install Mitogen for Ansible performance optimization
 # Following official installation instructions from https://mitogen.networkgenomics.com/ansible_detailed.html
-MITOGEN_VERSION="0.3.27"
+MITOGEN_VERSION="0.3.43"
 
 MITOGEN_DIR="vendor/mitogen-${MITOGEN_VERSION}"
 MITOGEN_URL="https://files.pythonhosted.org/packages/source/m/mitogen/mitogen-${MITOGEN_VERSION}.tar.gz"


### PR DESCRIPTION
## Summary
- Bumps `MITOGEN_VERSION` in `ansible/install_dependencies.sh` from `0.3.27` to `0.3.43`
- Aligns the installed mitogen version with the path already referenced in `ansible.cfg` (`vendor/mitogen-0.3.43/ansible_mitogen/plugins/strategy`), which would otherwise fail to load the strategy plugin on a fresh install

## Test plan
- [ ] Run `./ansible/install_dependencies.sh` and confirm `vendor/mitogen-0.3.43/` is created
- [ ] Run an ansible playbook and confirm the `mitogen_free` strategy loads without errors