### PR TITLE
chore: fail playbook if devnet_name is still "template"

### DIFF
--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -1,4 +1,18 @@
 - hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Fail if devnet_name is still set to the placeholder "template"
+      ansible.builtin.fail:
+        msg: |
+          ##############################################################
+          # ERROR: devnet_name is set to "template"!                   #
+          # Update group_vars/all/defaults.yaml with a real devnet     #
+          # name (e.g. the repository's first word) before running.    #
+          ##############################################################
+      when: devnet_name | default('') == 'template'
+      tags: always
+
+- hosts: localhost
   roles:
     - role: ethpandaops.general.ethereum_genesis
       tags: [ethereum_genesis]


### PR DESCRIPTION
## Summary
- Adds a `localhost` pre-play guard that aborts `ansible-playbook playbook.yaml` when `devnet_name` is still the placeholder `template` from `group_vars/all/defaults.yaml`.
- Tagged `always` so the check fires regardless of which `--tags` filter is used.

## Test plan
- [ ] `ansible-playbook playbook.yaml` against a fork that hasn't updated `devnet_name` fails with the helpful error.
- [ ] `ansible-playbook playbook.yaml` with `devnet_name` set to anything else proceeds normally.