### PR TITLE
Hetzner: cpx (new gen) defaults + capacity-aware placement

### DIFF
--- a/terraform/devnet-0/hetzner.tf
+++ b/terraform/devnet-0/hetzner.tf
@@ -8,12 +8,12 @@ variable "hcloud_ssh_key_fingerprint" {
 
 variable "hetzner_supernode_size" {
   type    = string
-  default = "cpx51"
+  default = "cx53"
 }
 
 variable "hetzner_fullnode_size" {
   type    = string
-  default = "cpx41"
+  default = "cx43"
 }
 
 variable "hetzner_regions" {

--- a/terraform/devnet-0/hetzner.tf
+++ b/terraform/devnet-0/hetzner.tf
@@ -8,12 +8,12 @@ variable "hcloud_ssh_key_fingerprint" {
 
 variable "hetzner_supernode_size" {
   type    = string
-  default = "cax41"
+  default = "cpx51"
 }
 
 variable "hetzner_fullnode_size" {
   type    = string
-  default = "cax31"
+  default = "cpx41"
 }
 
 variable "hetzner_regions" {

--- a/terraform/devnet-0/hetzner.tf
+++ b/terraform/devnet-0/hetzner.tf
@@ -8,12 +8,12 @@ variable "hcloud_ssh_key_fingerprint" {
 
 variable "hetzner_supernode_size" {
   type    = string
-  default = "cx53"
+  default = "cpx62"
 }
 
 variable "hetzner_fullnode_size" {
   type    = string
-  default = "cx43"
+  default = "cpx42"
 }
 
 variable "hetzner_regions" {
@@ -25,10 +25,43 @@ variable "hetzner_regions" {
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
+//                                        DATA SOURCES
+////////////////////////////////////////////////////////////////////////////////////////
+data "hcloud_server_type" "supernode" {
+  count = local.hetzner_has_servers ? 1 : 0
+  name  = var.hetzner_supernode_size
+}
+
+data "hcloud_server_type" "fullnode" {
+  count = local.hetzner_has_servers ? 1 : 0
+  name  = var.hetzner_fullnode_size
+}
+
+data "hcloud_datacenters" "all" {
+  count = local.hetzner_has_servers ? 1 : 0
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
 //                                        LOCALS
 ////////////////////////////////////////////////////////////////////////////////////////
 locals {
   hetzner_has_servers = length(local.hetzner_nodes) > 0
+
+  required_hetzner_server_type_ids = local.hetzner_has_servers ? toset([
+    tostring(data.hcloud_server_type.supernode[0].id),
+    tostring(data.hcloud_server_type.fullnode[0].id),
+  ]) : toset([])
+
+  hetzner_available_locations = local.hetzner_has_servers ? distinct([
+    for dc in data.hcloud_datacenters.all[0].datacenters : dc.location.name
+    if alltrue([for tid in local.required_hetzner_server_type_ids : contains([for id in dc.available_server_type_ids : tostring(id)], tid)])
+  ]) : []
+
+  hetzner_regions_filtered = [
+    for r in var.hetzner_regions : r if contains(local.hetzner_available_locations, r)
+  ]
+
+  hetzner_regions_effective = length(local.hetzner_regions_filtered) > 0 ? local.hetzner_regions_filtered : var.hetzner_regions
 
   hetzner_network = {
     for region in var.hetzner_regions : region => {
@@ -76,7 +109,7 @@ locals {
               ) ? var.hetzner_supernode_size : var.hetzner_fullnode_size
             )
 
-            location     = node.location != null ? node.location : var.hetzner_regions[i % length(var.hetzner_regions)]
+            location     = node.location != null ? node.location : local.hetzner_regions_effective[i % length(local.hetzner_regions_effective)]
             ipv4_enabled = node.ipv4_enabled
             ipv6_enabled = node.ipv6_enabled
           }
@@ -166,6 +199,10 @@ resource "hcloud_server" "main" {
     ipv4_enabled = each.value.ipv4_enabled
     ipv6_enabled = each.value.ipv6_enabled
   }
+
+  lifecycle {
+    ignore_changes = [location]
+  }
 }
 
 resource "hcloud_server_network" "main" {
@@ -173,5 +210,5 @@ resource "hcloud_server_network" "main" {
     for vm in local.hcloud_vms : vm.id => vm
   }
   server_id  = hcloud_server.main[each.key].id
-  network_id = hcloud_network.main[each.value.location].id
+  network_id = hcloud_network.main[hcloud_server.main[each.key].location].id
 }

--- a/terraform/devnet-0/hetzner.tf
+++ b/terraform/devnet-0/hetzner.tf
@@ -6,6 +6,10 @@ variable "hcloud_ssh_key_fingerprint" {
   default = "d6:76:2d:9c:5b:33:80:ff:0f:09:a2:10:9b:58:7e:dc"
 }
 
+# cpx* (AMD shared) defaults: cax* (ARM) capacity is unreliable and the
+# legacy cpx41/cpx51 SKUs are no longer creatable in some EU locations.
+# cpx42/cpx62 are widely stocked and still ~3-4x cheaper than DigitalOcean
+# for equivalent specs (e.g. cpx62 16/32/640 ~€50/mo vs DO ~€177/mo).
 variable "hetzner_supernode_size" {
   type    = string
   default = "cpx62"

--- a/terraform/devnet-0/hetzner.tf
+++ b/terraform/devnet-0/hetzner.tf
@@ -6,10 +6,6 @@ variable "hcloud_ssh_key_fingerprint" {
   default = "d6:76:2d:9c:5b:33:80:ff:0f:09:a2:10:9b:58:7e:dc"
 }
 
-# cpx* (AMD shared) defaults: cax* (ARM) capacity is unreliable and the
-# legacy cpx41/cpx51 SKUs are no longer creatable in some EU locations.
-# cpx42/cpx62 are widely stocked and still ~3-4x cheaper than DigitalOcean
-# for equivalent specs (e.g. cpx62 16/32/640 ~€50/mo vs DO ~€177/mo).
 variable "hetzner_supernode_size" {
   type    = string
   default = "cpx62"


### PR DESCRIPTION
## Summary

Two changes layered together to address recurring `resource_unavailable` and `unsupported location for server type` errors on `terraform apply`:

### 1. New default SKUs

| | Was | Now | nbg1 €/mo |
|---|---|---|---|
| supernode | `cax41` (16 ARM / 32 GB / 320 GB) | **`cpx62`** (16 AMD / 32 GB / 640 GB) | €50.49 |
| fullnode  | `cax31` (8 ARM / 16 GB / 160 GB)  | **`cpx42`** (8 AMD / 16 GB / 320 GB)  | €25.49 |

Hetzner ARM `cax*` capacity has been chronically tight, and the legacy `cpx41`/`cpx51` SKUs are no longer creatable in some EU locations. The new-gen `cpx42`/`cpx62` are widely available.

### Cost vs DigitalOcean

`cpx*` is more expensive than `cax*`/`cx*`, but **still dramatically cheaper than DigitalOcean** for equivalent specs:

| Spec | Hetzner cpx | DO equivalent |
|---|---|---|
| 8 vCPU / 16 GB / ~300 GB  | `cpx42` ≈ **€25/mo** | `s-8vcpu-16gb` ≈ €88/mo (~$96) |
| 16 vCPU / 32 GB / ~600 GB | `cpx62` ≈ **€50/mo** | `s-16vcpu-32gb` ≈ €177/mo (~$192) |

So we're roughly **3–4× cheaper than DO** while staying on a SKU that's actually in stock. For a multi-month devnet that's hundreds of euros saved per supernode.

The arch label logic at `hetzner.tf` already keys off the `^cax` regex, so labels automatically flip to `arch:amd64`.

### 2. Capacity-aware placement

At every plan/apply, query `hcloud_datacenters` and `hcloud_server_type` data sources, build the set of locations whose datacenters currently report **both** SKUs as `available`, and round-robin new servers only across those. Falls back to the full `var.hetzner_regions` list if every region is sold out (so plan doesn't error out — at that point you're stuck either way).

- `lifecycle { ignore_changes = [location] }` on `hcloud_server` keeps existing placements pinned even if next plan's filter would prefer a different region (location is replacement-forced on `hcloud_server` otherwise).
- `hcloud_server_network` now reads `hcloud_server.main[each.key].location` (the actual post-state location) so the network reference stays correct under any drift.

## Test plan

- [ ] Downstream devnet repos consuming this template plan cleanly
- [ ] Ansible playbooks resolve amd64 binaries/images for affected client and tooling roles
- [ ] First apply on a fresh devnet provisions servers without `resource_unavailable` / `unsupported location` errors
- [ ] `echo 'local.hetzner_available_locations' | terraform console` returns the expected non-empty list when capacity is healthy