### PR TITLE
otelcol: ship logs+traces to prod OTLP via upstream role

### DIFF
--- a/ansible/inventories/devnet-0/group_vars/all/all.yaml
+++ b/ansible/inventories/devnet-0/group_vars/all/all.yaml
@@ -274,6 +274,9 @@ docker_nginx_proxy_wildcard_cert_url: "http://cert.{{ network_server_subdomain }
 docker_nginx_proxy_wildcard_cert_psk: "{{ secret_cert_encryption_psk }}"
 
 # role: ethpandaops.general.vector
+# Ship docker logs to platform's ClickHouse logs-external pipeline.
+# Reuses secret_loki credentials — the same VMAuth backend fronts both ingresses.
+clickhouse_logs_endpoint: "https://logs-ingest.analytics.production.platform.ethpandaops.io"
 vector_config: |
   [sources.in]
     type = "docker_logs"
@@ -286,24 +289,31 @@ vector_config: |
       "snooper-",
     ]
 
-  [sinks.out]
-    type = "loki"
+  [transforms.clickhouse_shape]
+    type = "remap"
     inputs = ["in"]
-    out_of_order_action = "accept"
-    labels.forwarder = "vector"
-    labels.instance = "{{ inventory_hostname }}"
-    labels.network = "{{ ethereum_network_name }}"
-    labels.testnet = "{{ ethereum_network_name }}"
-    labels.ingress_user = "{{ secret_loki.username }}"
-    labels.container_name = "{{ '{{ container_name }}' }}"
-  {%- if ethereum_node_el is defined +%}
-    labels.ethereum_el = "{{ ethereum_node_el }}"
-  {%- endif +%}
-  {%- if ethereum_node_cl is defined +%}
-    labels.ethereum_cl = "{{ ethereum_node_cl }}"
-  {%- endif +%}
+    source = '''
+      .IngressUser = "{{ secret_loki.username }}"
+      .Namespace   = ""
+      .Pod         = ""
+      .Container   = string(.container_name) ?? ""
+      .Node        = "{{ inventory_hostname }}"
+      .Stream      = string(.stream) ?? ""
+      .Message     = string(.message) ?? ""
+      .Timestamp   = .timestamp
+      del(.container_name); del(.container_id); del(.container_created_at)
+      del(.image); del(.host); del(.label); del(.source_type)
+      del(.stream); del(.message); del(.timestamp)
+    '''
+
+  [sinks.clickhouse_logs]
+    type = "http"
+    inputs = ["clickhouse_shape"]
+    uri = "{{ clickhouse_logs_endpoint }}"
+    method = "post"
     encoding.codec = "json"
-    endpoint = "{{ secret_loki.endpoint }}"
     auth.strategy = "basic"
     auth.user = "{{ secret_loki.username }}"
     auth.password = "{{ secret_loki.password }}"
+    batch.max_events = 5000
+    batch.timeout_secs = 3

--- a/ansible/inventories/devnet-0/group_vars/all/all.yaml
+++ b/ansible/inventories/devnet-0/group_vars/all/all.yaml
@@ -274,9 +274,6 @@ docker_nginx_proxy_wildcard_cert_url: "http://cert.{{ network_server_subdomain }
 docker_nginx_proxy_wildcard_cert_psk: "{{ secret_cert_encryption_psk }}"
 
 # role: ethpandaops.general.vector
-# Ship docker logs to platform's ClickHouse logs-external pipeline.
-# Reuses secret_loki credentials — the same VMAuth backend fronts both ingresses.
-clickhouse_logs_endpoint: "https://logs-ingest.analytics.production.platform.ethpandaops.io"
 vector_config: |
   [sources.in]
     type = "docker_logs"
@@ -289,31 +286,24 @@ vector_config: |
       "snooper-",
     ]
 
-  [transforms.clickhouse_shape]
-    type = "remap"
+  [sinks.out]
+    type = "loki"
     inputs = ["in"]
-    source = '''
-      .IngressUser = "{{ secret_loki.username }}"
-      .Namespace   = ""
-      .Pod         = ""
-      .Container   = string(.container_name) ?? ""
-      .Node        = "{{ inventory_hostname }}"
-      .Stream      = string(.stream) ?? ""
-      .Message     = string(.message) ?? ""
-      .Timestamp   = .timestamp
-      del(.container_name); del(.container_id); del(.container_created_at)
-      del(.image); del(.host); del(.label); del(.source_type)
-      del(.stream); del(.message); del(.timestamp)
-    '''
-
-  [sinks.clickhouse_logs]
-    type = "http"
-    inputs = ["clickhouse_shape"]
-    uri = "{{ clickhouse_logs_endpoint }}"
-    method = "post"
+    out_of_order_action = "accept"
+    labels.forwarder = "vector"
+    labels.instance = "{{ inventory_hostname }}"
+    labels.network = "{{ ethereum_network_name }}"
+    labels.testnet = "{{ ethereum_network_name }}"
+    labels.ingress_user = "{{ secret_loki.username }}"
+    labels.container_name = "{{ '{{ container_name }}' }}"
+  {%- if ethereum_node_el is defined +%}
+    labels.ethereum_el = "{{ ethereum_node_el }}"
+  {%- endif +%}
+  {%- if ethereum_node_cl is defined +%}
+    labels.ethereum_cl = "{{ ethereum_node_cl }}"
+  {%- endif +%}
     encoding.codec = "json"
+    endpoint = "{{ secret_loki.endpoint }}"
     auth.strategy = "basic"
     auth.user = "{{ secret_loki.username }}"
     auth.password = "{{ secret_loki.password }}"
-    batch.max_events = 5000
-    batch.timeout_secs = 3

--- a/ansible/inventories/devnet-0/group_vars/all/all.yaml
+++ b/ansible/inventories/devnet-0/group_vars/all/all.yaml
@@ -274,6 +274,8 @@ docker_nginx_proxy_wildcard_cert_url: "http://cert.{{ network_server_subdomain }
 docker_nginx_proxy_wildcard_cert_psk: "{{ secret_cert_encryption_psk }}"
 
 # role: ethpandaops.general.vector
+# Ship docker logs to platform's ClickHouse logs-external pipeline.
+# Reuses secret_loki credentials — the same VMAuth backend fronts both ingresses.
 clickhouse_logs_endpoint: "https://logs-ingest.analytics.production.platform.ethpandaops.io"
 vector_config: |
   [sources.in]

--- a/ansible/inventories/devnet-0/group_vars/all/all.yaml
+++ b/ansible/inventories/devnet-0/group_vars/all/all.yaml
@@ -274,8 +274,6 @@ docker_nginx_proxy_wildcard_cert_url: "http://cert.{{ network_server_subdomain }
 docker_nginx_proxy_wildcard_cert_psk: "{{ secret_cert_encryption_psk }}"
 
 # role: ethpandaops.general.vector
-# Ship docker logs to platform's ClickHouse logs-external pipeline.
-# Reuses secret_loki credentials — the same VMAuth backend fronts both ingresses.
 clickhouse_logs_endpoint: "https://logs-ingest.analytics.production.platform.ethpandaops.io"
 vector_config: |
   [sources.in]

--- a/ansible/inventories/devnet-0/group_vars/all/all.yaml
+++ b/ansible/inventories/devnet-0/group_vars/all/all.yaml
@@ -334,7 +334,7 @@ otelcol_contrib_config: |
           format: docker
           add_metadata_from_filepath: true
         - type: filter
-          expr: 'attributes["container.name"] != nil and attributes["container.name"] matches "^(otelcol|ethereum-metrics-exporter|nginx-proxy|node_exporter|prometheus|snooper-.*)$"'
+          expr: '(attributes["container.name"] != nil and attributes["container.name"] matches "^(otelcol|ethereum-metrics-exporter|nginx-proxy|node_exporter|prometheus|snooper-.*)$") or body matches "github\\.com/open-telemetry/opentelemetry-collector-contrib|otelcol-contrib"'
         - type: json_parser
           if: 'body matches "^\\s*\\{"'
           on_error: send

--- a/ansible/inventories/devnet-0/group_vars/all/all.yaml
+++ b/ansible/inventories/devnet-0/group_vars/all/all.yaml
@@ -273,12 +273,22 @@ docker_nginx_proxy_wildcard_cert: "{{ network_server_subdomain }}"
 docker_nginx_proxy_wildcard_cert_url: "http://cert.{{ network_server_subdomain }}/{{ network_server_subdomain }}-latest.tar.enc"
 docker_nginx_proxy_wildcard_cert_psk: "{{ secret_cert_encryption_psk }}"
 
-# role: ethpandaops.general.vector
+# role: ethpandaops.general.otelcol_contrib
+# Reuses secret_loki credentials (same vmauth backend serves both ingresses).
+otlp_endpoint: "https://otlp.analytics.production.platform.ethpandaops.io"
+otlp_deployment_env: production
+
+otelcol_contrib_container_networks: "{{ docker_networks_shared }}"
+
+# Vector kept alongside otelcol just to ship logs to Loki. Will be removed
+# when Loki path is replaced (e.g. central aggregator or Loki OTLP support).
+vector_container_networks: "{{ docker_networks_shared }}"
 vector_config: |
   [sources.in]
     type = "docker_logs"
     exclude_containers = [
       "{{ vector_container_name }}",
+      "otelcol",
       "ethereum-metrics-exporter",
       "nginx-proxy",
       "node_exporter",
@@ -286,7 +296,7 @@ vector_config: |
       "snooper-",
     ]
 
-  [sinks.out]
+  [sinks.loki]
     type = "loki"
     inputs = ["in"]
     out_of_order_action = "accept"
@@ -307,3 +317,73 @@ vector_config: |
     auth.strategy = "basic"
     auth.user = "{{ secret_loki.username }}"
     auth.password = "{{ secret_loki.password }}"
+otelcol_contrib_config: |
+  extensions:
+    basicauth/client:
+      client_auth:
+        username: {{ secret_loki.username }}
+        password: {{ secret_loki.password }}
+
+  receivers:
+    filelog:
+      include: [/var/lib/docker/containers/*/*-json.log]
+      include_file_path: true
+      start_at: end
+      operators:
+        - type: container
+          format: docker
+          add_metadata_from_filepath: true
+        - type: filter
+          expr: 'attributes["container.name"] != nil and attributes["container.name"] matches "^(otelcol|ethereum-metrics-exporter|nginx-proxy|node_exporter|prometheus|snooper-.*)$"'
+        - type: json_parser
+          if: 'body matches "^\\s*\\{"'
+          on_error: send
+          severity:
+            parse_from: attributes.level
+            overwrite_text: true
+            mapping:
+              fatal4: [emergency, emerg]
+              fatal3: [alert]
+              fatal2: [critical, crit]
+              fatal:  [panic]
+
+    otlp:
+      protocols:
+        grpc: {endpoint: "[::]:4317"}
+        http: {endpoint: "[::]:4318"}
+
+  processors:
+    resource:
+      attributes:
+        - {key: deployment.environment, value: "{{ otlp_deployment_env }}", action: upsert}
+        - {key: network,                value: "{{ ethereum_network_name }}", action: upsert}
+        - {key: ingress_user,           value: "{{ secret_loki.username }}", action: upsert}
+        - {key: host.name,              value: "{{ inventory_hostname }}", action: upsert}
+
+    transform/service_name:
+      log_statements:
+        - context: resource
+          statements:
+            - set(attributes["service.name"], attributes["container.name"]) where attributes["container.name"] != nil
+
+    batch:
+      send_batch_size: 500
+      timeout: 5s
+
+  exporters:
+    otlphttp/staging:
+      endpoint: "{{ otlp_endpoint }}"
+      auth:
+        authenticator: basicauth/client
+
+  service:
+    extensions: [basicauth/client]
+    pipelines:
+      logs:
+        receivers: [filelog, otlp]
+        processors: [resource, transform/service_name, batch]
+        exporters: [otlphttp/staging]
+      traces:
+        receivers: [otlp]
+        processors: [resource, batch]
+        exporters: [otlphttp/staging]

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -43,6 +43,8 @@
       tags: [init-server, node_exporter]
     - role: ethpandaops.general.prometheus
       tags: [init-server, prometheus]
+    - role: ethpandaops.general.otelcol_contrib
+      tags: [init-server, otelcol]
     - role: ethpandaops.general.vector
       tags: [init-server, vector]
 


### PR DESCRIPTION
Adds `ethpandaops.general.otelcol_contrib` (now provided by the collection) alongside vector. New devnets generated from this template will ship logs + traces to `https://otlp.analytics.production.platform.ethpandaops.io`, where vmauth tags them as external tier and routes into `external.otel_logs` / `external.otel_traces` in ClickHouse.

Vector stays as the Loki shipper for now — same dual-write pattern we kept when migrating blob-devnets, glamsterdam-devnets, and bal-devnets. Earlier vector→clickhouse_logs sink approach (reverted in this PR) is superseded by the otelcol path.