### PR TITLE
inventory: rename ethereum_node_fact_{cl_enr,el_enode} → _discovery_ variants

### DIFF
--- a/ansible/inventories/devnet-0/group_vars/bootnode.yaml
+++ b/ansible/inventories/devnet-0/group_vars/bootnode.yaml
@@ -70,7 +70,7 @@ teku_container_command_extra_args:
       (
         (
           groups['bootnode']
-          | map('extract', hostvars, ['ethereum_node_fact_cl_enr'])
+          | map('extract', hostvars, ['ethereum_node_fact_discovery_cl_enr'])
           | select('defined')
           | list
         )
@@ -109,7 +109,7 @@ geth_container_command_extra_args:
       (
         (
           groups['bootnode']
-          | map('extract', hostvars, ['ethereum_node_fact_el_enode'])
+          | map('extract', hostvars, ['ethereum_node_fact_discovery_el_enode'])
           | select('defined')
           | list
         )

--- a/ansible/inventories/devnet-0/group_vars/ethereum_node.yaml
+++ b/ansible/inventories/devnet-0/group_vars/ethereum_node.yaml
@@ -1,10 +1,10 @@
 ethereum_cl_bootnodes:
   - "{{ hostvars[primary_bootnode]['bootnodoor_fact_enr'] }}"
-  - "{{ hostvars[primary_bootnode]['ethereum_node_fact_cl_enr'] }}"
+  - "{{ hostvars[primary_bootnode]['ethereum_node_fact_discovery_cl_enr'] }}"
 
 ethereum_el_bootnodes:
   - "{{ hostvars[primary_bootnode]['bootnodoor_fact_enode'] }}"
-  - "{{ hostvars[primary_bootnode]['ethereum_node_fact_el_enode'] }}"
+  - "{{ hostvars[primary_bootnode]['ethereum_node_fact_discovery_el_enode'] }}"
 
 ethereum_node_xatu_sentry_enabled: true
 

--- a/ansible/inventories/devnet-0/host_vars/mev-relay-1.yaml
+++ b/ansible/inventories/devnet-0/host_vars/mev-relay-1.yaml
@@ -138,10 +138,10 @@ lighthouse_validator_datadir: /data/lighthouse-validator
 lighthouse_container_pull: true
 
 ethereum_el_bootnodes:
-  - "{{ hostvars[primary_bootnode]['ethereum_node_fact_el_enode'] }}"
+  - "{{ hostvars[primary_bootnode]['ethereum_node_fact_discovery_el_enode'] }}"
 
 ethereum_cl_bootnodes:
-  - "{{ hostvars[primary_bootnode]['ethereum_node_fact_cl_enr'] }}"
+  - "{{ hostvars[primary_bootnode]['ethereum_node_fact_discovery_cl_enr'] }}"
 
 # role: ethpandaops.general.ethereum_node
 ethereum_node_el: reth


### PR DESCRIPTION
Catches the devnet-0 inventory up to ansible-collection-general PR #509, which renamed `ethereum_node_fact_{cl_enr,el_enode}` to `ethereum_node_fact_discovery_{cl_enr,el_enode}`. Without this, container-recreate playbooks fail with `HostVarsVars object has no attribute ethereum_node_fact_cl_enr` for anyone who has run `install_dependencies.sh`. Same fix as blob-devnets#14, bal-devnets#50, glamsterdam-devnets#5.