### PR TITLE
ethrex: enable admin RPC namespace so Dora can read node info

### DIFF
--- a/ansible/inventories/devnet-0/group_vars/ethrex.yaml
+++ b/ansible/inventories/devnet-0/group_vars/ethrex.yaml
@@ -21,6 +21,7 @@ ethrex_container_volumes:
 ethrex_container_command_extra_args:
   - --network=/network-config/genesis.json
   - --bootnodes={{ ethereum_el_bootnodes | join(',') }}
+  - --http.api=eth,net,web3,admin,debug,txpool
 
 prometheus_config: |
   global:


### PR DESCRIPTION
## Problem

ethrex defaults `--http.api` to `eth,net,web3` — the `admin` namespace is opt-in (`lambdaclass/ethrex` `cmd/ethrex/cli.rs`). Every other execution client we run enables `admin` (geth/reth/erigon/besu/nethermind/nimbus all do), but the ethrex template never set `--http.api`.

Dora derives an EL's **status and version** on `/api/v1/clients/execution` *solely* from `admin_nodeInfo` (`dora` `clients/execution/clientlogic.go` → `client.nodeInfo`; `handlers/api/api_clients_el.go` reports `disconnected`/empty version when it's nil). With `admin` disabled, `admin_nodeInfo` returns `MethodNotFound`, so ethrex shows as **disconnected with an empty version even while healthy and proposing blocks** (block production uses the `engine` authrpc port, not `admin`).

That empty version then cascades:
- **cartographoor** infers `clientType` from the version string → empty
- **homepage** hides the client `<img>` when `clientType` is empty → the ethrex logo goes missing on the network/instances pages

Observed on bal-devnet-7, where both ethrex instances showed `disconnected`/no logo while every connected EL rendered fine.

## Fix

Add `--http.api=eth,net,web3,admin,debug,txpool` to the ethrex template's `ethrex_container_command_extra_args`, matching the namespaces every other EL exposes. (`engine` is intentionally excluded — ethrex serves it on the authenticated RPC port and rejects it here.)

This is the scaffolding template for new devnets, so fixing it here prevents the bug from recurring. The same gap exists in current bal-devnets (devnet-2/3/5/6/7) and the `ethereum-package` ethrex launcher.