### PR TITLE
feat: expose watchtower HTTP API for gated rollouts

### DIFF
--- a/ansible/inventories/devnet-0/group_vars/all/all.sops.yaml
+++ b/ansible/inventories/devnet-0/group_vars/all/all.sops.yaml
@@ -38,14 +38,15 @@ tysm_secret_key: ENC[AES256_GCM,data:MuvclVLaNVZ+7vRumg==,iv:XGBLMISj2wL7MQznXnV
 tempo_grpc_url: ENC[AES256_GCM,data:ltAVTGgrqhUBXdAZe7D1HvdXK72YIORL/x4DYHgX911s+X8IZM9/guRqE1I/ZYSzNrQX0qON3/TrNSjpG1BUpkK9M0SLzqE4EKhaOOQonJRLunnufZVrZIDhXSMaGQhZcjsHQCV8,iv:4mzqA4Ck1g91+tST5oTSnTepikjOCWKJrV04Rsp/8Ts=,tag:MgjQUb+lR1SIU2d8KpvOew==,type:str]
 secret_buildoor_builder_privkey: ENC[AES256_GCM,data:FJj3WPEad/nxomBuvOcKYwuZRb1wpH/AV742UoSQimMDGZZ6ZuPLG9MRTXPEXlAX2oojiOPLN22XLae8PZ6mrg==,iv:PaHUBXc58KzROm9swDMeTuH55iZoSXpjZbmhhBlXVqQ=,tag:QtSpaxciweQhKEML+ZmbJA==,type:str]
 secret_buildoor_wallet_privkey: ENC[AES256_GCM,data:K4iVB2j+py1CYUsR6j7UUPtGVMeYdIkV9EY0Foi23lr7toUSlLTfqqZE23u533YQrpovinMl4z2Gji8V1VGAeA==,iv:POAoPAmGeZTYoqwGsSB8NMSI4MsCMMbIhv3zefnzfE4=,tag:05IHrIPCpwJnMafB3nDE8g==,type:str]
+secret_watchtower_api_token: ENC[AES256_GCM,data:2zrCM7CycAblVBME/QYUJVwQyq8y1rK3VioUuRWsp0IXeyXE,iv:IJ6B/a/Ph0PFngexZm+B2RwbcjRrKOAc1R1V67m/lD8=,tag:2o6cv+gfXIEGLrdRZO7Mug==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2026-04-29T09:20:00Z"
-    mac: ENC[AES256_GCM,data:c/HVw/mtY1gAFLIc7K+uQbI2UdU1vs4ppVcoUQswUH3hSA6WIuUrpEzQCkP2xwKazPsE8ReK4ICY5oQVXgBWZsoUAyj2/gSpBGRsQbEsc/qUf32MthXPJaT5ulxkH06iCzFvHzD+doECGgtOZFU/KLvwV5tj88MbxGCy9+KYNRA=,iv:ftc09zuBrYKFzxhwAbO+vbEm1IFkU+qzbenN+Yz5ho8=,tag:8KlHK07wfyZOKI315Rf4WQ==,type:str]
+    lastmodified: "2026-05-29T14:29:21Z"
+    mac: ENC[AES256_GCM,data:L+zvY0TE08jW5hP+HMltY6jKJ/wBHb4C0Qjh4/CLaVPAsfTHN/tO5UvBafdrSiam6zWdYe4s4QAmrSqCSD+knP+VwgO9M1BkFA+DSRmX/GbZZfL800XmJSsmfmRyjWxNu0naGZNcxe+H44CCLjuvV7hhVKcMlkeUkrCbHf+U2Z0=,iv:pKzoQW13nqa1BDq+uhdcul0sMVCzRMb0mJMk9IlSirs=,tag:AsTsGBIwiupf9IKoj8WjgQ==,type:str]
     pgp:
         - created_at: "2025-10-27T13:25:35Z"
           enc: |-

--- a/ansible/inventories/devnet-0/group_vars/all/all.yaml
+++ b/ansible/inventories/devnet-0/group_vars/all/all.yaml
@@ -158,10 +158,10 @@ docker_watchtower_container_additional_args:
 # Requires secret_watchtower_api_token in this devnet's all.sops.yaml.
 docker_watchtower_container_networks: "{{ docker_networks_shared }}"
 docker_watchtower_container_env:
-    WATCHTOWER_HTTP_API_TOKEN: "{{ secret_watchtower_api_token }}"
-    VIRTUAL_HOST: "{{ ethereum_node_watchtower_hostname }}"
-    VIRTUAL_PORT: "8080"
-    LETSENCRYPT_HOST: "{{ ethereum_node_watchtower_hostname }}"
+  WATCHTOWER_HTTP_API_TOKEN: "{{ secret_watchtower_api_token }}"
+  VIRTUAL_HOST: "{{ ethereum_node_watchtower_hostname }}"
+  VIRTUAL_PORT: "8080"
+  LETSENCRYPT_HOST: "{{ ethereum_node_watchtower_hostname }}"
 ethereum_node_json_rpc_snooper_engine_enabled: true
 ethereum_node_json_rpc_snooper_engine_name: "snooper-engine"
 ethereum_node_json_rpc_snooper_engine_port: 8561

--- a/ansible/inventories/devnet-0/group_vars/all/all.yaml
+++ b/ansible/inventories/devnet-0/group_vars/all/all.yaml
@@ -20,8 +20,10 @@ ethereum_network_deposit_contract_block: >-
 
 ethereum_node_rpc_prefix: "rpc-" # prefix for rpc URLs
 ethereum_node_beacon_prefix: "bn-" # prefix for beacon URLs
+ethereum_node_watchtower_prefix: "watchtower-" # prefix for watchtower HTTP API URLs
 ethereum_node_rcp_hostname: "{{ ethereum_node_rpc_prefix }}{{ server_fqdn }}"
 ethereum_node_beacon_hostname: "{{ ethereum_node_beacon_prefix }}{{ server_fqdn }}"
+ethereum_node_watchtower_hostname: "{{ ethereum_node_watchtower_prefix }}{{ server_fqdn }}"
 
 primary_bootnode: bootnode-1
 
@@ -148,9 +150,18 @@ ethereum_node_docker_watchtower_containers_list:
   - xatu-sentry
   - external-block-builder
 docker_watchtower_container_additional_args:
-  - --interval=900
+  - --http-api-update
   - --stop-timeout=300s
   - --include-restarting
+# Join the nginx-proxy network and expose the HTTP API at watchtower-<fqdn>
+# (like bn-/rpc-), so the panda-pulse /roll command can reach it over HTTPS.
+# Requires secret_watchtower_api_token in this devnet's all.sops.yaml.
+docker_watchtower_container_networks: "{{ docker_networks_shared }}"
+docker_watchtower_container_env:
+    WATCHTOWER_HTTP_API_TOKEN: "{{ secret_watchtower_api_token }}"
+    VIRTUAL_HOST: "{{ ethereum_node_watchtower_hostname }}"
+    VIRTUAL_PORT: "8080"
+    LETSENCRYPT_HOST: "{{ ethereum_node_watchtower_hostname }}"
 ethereum_node_json_rpc_snooper_engine_enabled: true
 ethereum_node_json_rpc_snooper_engine_name: "snooper-engine"
 ethereum_node_json_rpc_snooper_engine_port: 8561

--- a/ansible/inventories/devnet-0/group_vars/dns_server.yaml
+++ b/ansible/inventories/devnet-0/group_vars/dns_server.yaml
@@ -53,11 +53,13 @@ dns_server_zones:
       {{ hostvars[host]['inventory_hostname'] }}                                   IN  A     {{ hostvars[host]['ansible_host'] }}
       {{ ethereum_node_rpc_prefix }}{{ hostvars[host]['inventory_hostname'] }}     IN  A     {{ hostvars[host]['ansible_host'] }}
       {{ ethereum_node_beacon_prefix }}{{ hostvars[host]['inventory_hostname'] }}  IN  A     {{ hostvars[host]['ansible_host'] }}
+      {{ ethereum_node_watchtower_prefix }}{{ hostvars[host]['inventory_hostname'] }}  IN  A     {{ hostvars[host]['ansible_host'] }}
       {% if hostvars[host]['ipv6'] is defined %}
       {{ hostvars[host]['inventory_hostname'] }}                                   IN  AAAA  {{ hostvars[host]['ipv6'] }}
       {% set proxy_ipv6 = hostvars[host].get('docker_nginx_proxy_public_ipv6', hostvars[host]['ipv6']) %}
       {{ ethereum_node_rpc_prefix }}{{ hostvars[host]['inventory_hostname'] }}     IN  AAAA  {{ proxy_ipv6 if proxy_ipv6 | length > 0 else hostvars[host]['ipv6'] }}
       {{ ethereum_node_beacon_prefix }}{{ hostvars[host]['inventory_hostname'] }}  IN  AAAA  {{ proxy_ipv6 if proxy_ipv6 | length > 0 else hostvars[host]['ipv6'] }}
+      {{ ethereum_node_watchtower_prefix }}{{ hostvars[host]['inventory_hostname'] }}  IN  AAAA  {{ proxy_ipv6 if proxy_ipv6 | length > 0 else hostvars[host]['ipv6'] }}
       {% endif %}
       {% endfor %}
 

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -102,8 +102,8 @@
       tags: [eth_inventory_web, ethereum_inventory_web]
       when: inventory_hostname == primary_bootnode
       vars:
-        eth_inventory_web_container_networks: "{{ docker_networks_shared }}" #noqa var-naming[no-role-prefix]
-        eth_inventory_web_container_env: #noqa var-naming[no-role-prefix]
+        eth_inventory_web_container_networks: "{{ docker_networks_shared }}" # noqa: var-naming[no-role-prefix]
+        eth_inventory_web_container_env: # noqa: var-naming[no-role-prefix]
           VIRTUAL_HOST: "{{ primary_bootnode }}.{{ network_server_subdomain }}"
           VIRTUAL_PORT: "80"
           VIRTUAL_PATH: "/meta/api"

--- a/setup.sh
+++ b/setup.sh
@@ -23,3 +23,7 @@ export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
 
 # Install python tools
 python -m pip install -r requirements.txt
+
+# Regenerate shims so pip-installed console scripts (ansible-lint, ansible,
+# molecule) resolve on PATH in subsequent steps.
+asdf reshim python


### PR DESCRIPTION
## Summary

Expose each node's watchtower HTTP API at a `watchtower-<host>` vhost (the same nginx-proxy pattern as `bn-`/`rpc-`), so panda-pulse's `/roll` command can trigger gated, sequential image rollouts over HTTPS with a bearer token — no SSH. Mirrors ethpandaops/glamsterdam-devnets#8 in the template so new devnets get it by default.

Also switches watchtower from `--interval=900` (auto-poll) to `--http-api-update` (**trigger-only**): images no longer roll on a timer, only when explicitly triggered.

## Changes

- **`all.yaml`** — add `ethereum_node_watchtower_prefix`/`_hostname`; put the watchtower container on the shared network with `VIRTUAL_HOST`/`VIRTUAL_PORT`/`LETSENCRYPT_HOST` + `WATCHTOWER_HTTP_API_TOKEN`; replace `--interval=900` with `--http-api-update`.
- **`dns_server.yaml`** — add `watchtower-<host>` A/AAAA records for `ethereum_node` hosts.

## Note

Each devnet created from this template must add `secret_watchtower_api_token` to its `all.sops.yaml`.