### PR TITLE
ansible: source SSH rosters from coredevs

### DIFF
--- a/ansible/inventories/devnet-0/group_vars/all/all.yaml
+++ b/ansible/inventories/devnet-0/group_vars/all/all.yaml
@@ -95,15 +95,16 @@ ethereum_genesis_validator_keyranges: >-
 bootstrap_default_user_authorized_keys_plain:
   - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDbboxOo0jyL3DNxqZ6UTEnZPEzPDPnujEYaClqNWSLWkphczHKAnJPkrwbAWB4JbJKjsAJ5kn53f10KPnUyZvJ5Jn8Rpf7RM7+56MYaBg84gVoA2KeIYxUa7h8neY7J61Galp0c6cOK+hp1lPsoiBSdCW/Rtbv6ALCcVe+4+uCW5FRoJcNRJfGRLRnjh1pw57HQw9O55mf319s4rVUq4umznQ0CciEx3rVMtXf4xjIZDZAhNpGaBh8AtHauaMZCOGociAIquYYqoSQnnmnOBiduRa5OkvGZomgybNQivlYboDeF6sQ71KVzRXSI+mxCYbSp246lqSdQtQsjFA54NYl/qWgAql0uqCqsZidW+XBjquyItRl2Rfzzy5Fk/gMOAJXHQYp4POfgFbqtxjWpfnuOKqW/1IGWcIt2g016effUqGgj/oePX0g+duFdszSKK773rJBySgafFF6XWNqagrLmE4LUGC+6P3oxzYTSFGeUVA21OayL+K40XPpJti5zns= # devops-eth2-shared"
   - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDWh9NW66VD4BPKETNyZeZrGN1f7G6dkihW3eAc7cbJPFQGIpnWc2tGq5o13vWW+SoCh16nkYM2oak+PJQxXYTiQnrMJSmSFd7E0DmdcoKadGJEnfosrH++aOZf/eVLe5q3E9NQFVSdOPo1MCRRTuZxPkuMxS6QikW3otWrA3F2vFgmYyki3Cy8huQzHKUZGicividYcUSFTydR2L0oWUNve3FyqMQQQPnfaJ1RvrkeGtdhRSAxa6L0jzgRK7fjpUyhKOofr7kCKARGELRRiB9QikRAoHU2/D/2jtJjKlTCJxArzXyDF2IcQCco+5Oe9x4c7Xch32dbscJSmjaAvsxRnu7GEFCS7b6kKGvwcoq5vJzvp3RBBR7Mosxv6pcM/q7Z4RhXOFVFFiPVl1dqkqSPkUrHwg8LtWOxC+GAl36vxhHLdDEV/RhbSAzO6SfYEWYGH1w7u4oiy2XAT2cNCO0j0tSHS5chX+d7TzwAbBE2HuPL84GVGHZG875hmiE+Dok= # github-actions-ci"
-bootstrap_default_user_authorized_keys_github_all:
-  - barnabasbusa
-  - parithosh
-  - samcm
-  - savid
-  - skylenet
-  - pk910
-  - mattevans
-  - qu0b
+# Per-client team SSH rosters are fetched at runtime from the coredevs registry
+# (see each client group_vars file). https://github.com/ethpandaops/coredevs
+coredevs_api_url: https://coredevs.analytics.production.platform.ethpandaops.io
+
+# ethpandaops core team, sourced from the coredevs ethpandaops team. Handles not
+# in the coredevs team go in the extra list.
+github_all_extra_users: []
+bootstrap_default_user_authorized_keys_github_all: >-
+  {{ (query('ethpandaops.general.url_cached', coredevs_api_url ~ '/api/v1/users/ethpandaops?format=txt') | select | list)
+     + github_all_extra_users }}
 
 bootstrap_default_user_authorized_keys_github: >
   {{

--- a/ansible/inventories/devnet-0/group_vars/besu.yaml
+++ b/ansible/inventories/devnet-0/group_vars/besu.yaml
@@ -1,18 +1,8 @@
 # role: ethpandaops.general.bootstrap
-bootstrap_default_user_authorized_keys_github_team_el:
-  - garyschulte
-  - jflo
-  - fab-10
-  - matkt
-  - Gabriel-Trintinalia
-  - siladu
-  - pinges
-  - jframe
-  - ahamlat
-  - macfarla
-  - daniellehrner
-  - kkaur01
-  - joshuafernandes
+besu_extra_github_users: []  # handles not yet in the coredevs registry
+bootstrap_default_user_authorized_keys_github_team_el: >-
+  {{ (query('ethpandaops.general.url_cached', coredevs_api_url ~ '/api/v1/users/besu?format=txt') | select | list)
+     + besu_extra_github_users }}
 
 # role: ethpandaops.general.ethereum_node
 ethereum_node_el: besu

--- a/ansible/inventories/devnet-0/group_vars/erigon.yaml
+++ b/ansible/inventories/devnet-0/group_vars/erigon.yaml
@@ -1,8 +1,8 @@
 # role: ethpandaops.general.bootstrap
-bootstrap_default_user_authorized_keys_github_team_el:
-  - Giulio2002
-  - yperbasis
-  - taratorio
+erigon_extra_github_users: []  # handles not yet in the coredevs registry
+bootstrap_default_user_authorized_keys_github_team_el: >-
+  {{ (query('ethpandaops.general.url_cached', coredevs_api_url ~ '/api/v1/users/erigon?format=txt') | select | list)
+     + erigon_extra_github_users }}
 
 # role: ethpandaops.general.ethereum_node
 ethereum_node_el: erigon

--- a/ansible/inventories/devnet-0/group_vars/ethrex.yaml
+++ b/ansible/inventories/devnet-0/group_vars/ethrex.yaml
@@ -1,8 +1,8 @@
 # role: ethpandaops.general.bootstrap
-bootstrap_default_user_authorized_keys_github_team_el:
-  - edg-l
-  - JereSalo
-  - ilitteri
+ethrex_extra_github_users: []  # handles not yet in the coredevs registry
+bootstrap_default_user_authorized_keys_github_team_el: >-
+  {{ (query('ethpandaops.general.url_cached', coredevs_api_url ~ '/api/v1/users/ethrex?format=txt') | select | list)
+     + ethrex_extra_github_users }}
 
 # role: ethpandaops.general.ethereum_node
 ethereum_node_el: ethrex

--- a/ansible/inventories/devnet-0/group_vars/geth.yaml
+++ b/ansible/inventories/devnet-0/group_vars/geth.yaml
@@ -1,8 +1,8 @@
 # role: ethpandaops.general.bootstrap
-bootstrap_default_user_authorized_keys_github_team_el:
-  - mariusVanDerWijden
-  - lightclient
-  - rjl493456442
+geth_extra_github_users: []  # handles not yet in the coredevs registry
+bootstrap_default_user_authorized_keys_github_team_el: >-
+  {{ (query('ethpandaops.general.url_cached', coredevs_api_url ~ '/api/v1/users/geth?format=txt') | select | list)
+     + geth_extra_github_users }}
 
 # role: ethpandaops.general.ethereum_node
 ethereum_node_el: geth

--- a/ansible/inventories/devnet-0/group_vars/grandine.yaml
+++ b/ansible/inventories/devnet-0/group_vars/grandine.yaml
@@ -1,9 +1,8 @@
 # role: ethpandaops.general.bootstrap
-bootstrap_default_user_authorized_keys_github_team_cl:
-  - sauliusgrigaitis
-  - tumas
-  - povi
-  - hangleang
+grandine_extra_github_users: []  # handles not yet in the coredevs registry
+bootstrap_default_user_authorized_keys_github_team_cl: >-
+  {{ (query('ethpandaops.general.url_cached', coredevs_api_url ~ '/api/v1/users/grandine?format=txt') | select | list)
+     + grandine_extra_github_users }}
 
 # role: geerlingguy.docker
 docker_daemon_options:

--- a/ansible/inventories/devnet-0/group_vars/lighthouse.yaml
+++ b/ansible/inventories/devnet-0/group_vars/lighthouse.yaml
@@ -1,14 +1,8 @@
 # role: ethpandaops.general.bootstrap
-bootstrap_default_user_authorized_keys_github_team_cl:
-  - AgeManning
-  - ethdreamer
-  - paulhauner
-  - pawanjay176
-  - michaelsproul
-  - antondlr
-  - realbigsean
-  - jimmygchen
-  - dapplion
+lighthouse_extra_github_users: []  # handles not yet in the coredevs registry
+bootstrap_default_user_authorized_keys_github_team_cl: >-
+  {{ (query('ethpandaops.general.url_cached', coredevs_api_url ~ '/api/v1/users/lighthouse?format=txt') | select | list)
+     + lighthouse_extra_github_users }}
 
 # role: validator_keys
 validator_keys_sync_files:

--- a/ansible/inventories/devnet-0/group_vars/lodestar.yaml
+++ b/ansible/inventories/devnet-0/group_vars/lodestar.yaml
@@ -1,13 +1,8 @@
 # role: ethpandaops.general.bootstrap
-bootstrap_default_user_authorized_keys_github_team_cl:
-  - wemeetagain
-  - twoeths
-  - g11tech
-  - philknows
-  - nazarhussain
-  - nflaig
-  - matthewkeil
-  - ensi321
+lodestar_extra_github_users: []  # handles not yet in the coredevs registry
+bootstrap_default_user_authorized_keys_github_team_cl: >-
+  {{ (query('ethpandaops.general.url_cached', coredevs_api_url ~ '/api/v1/users/lodestar?format=txt') | select | list)
+     + lodestar_extra_github_users }}
 
 # role: validator_keys
 validator_keys_sync_files:

--- a/ansible/inventories/devnet-0/group_vars/nethermind.yaml
+++ b/ansible/inventories/devnet-0/group_vars/nethermind.yaml
@@ -1,15 +1,8 @@
 # role: ethpandaops.general.bootstrap
-bootstrap_default_user_authorized_keys_github_team_el:
-  - MarekM25
-  - kamilchodola
-  - LukaszRozmej
-  - marcindsobczak
-  - asdacap
-  - rubo
-  - smartprogrammer93
-  - cbermudez97
-  - flcl42
-  - stdevMac
+nethermind_extra_github_users: []  # handles not yet in the coredevs registry
+bootstrap_default_user_authorized_keys_github_team_el: >-
+  {{ (query('ethpandaops.general.url_cached', coredevs_api_url ~ '/api/v1/users/nethermind?format=txt') | select | list)
+     + nethermind_extra_github_users }}
 
 # role: ethpandaops.general.ethereum_node
 ethereum_node_el: nethermind

--- a/ansible/inventories/devnet-0/group_vars/nimbus.yaml
+++ b/ansible/inventories/devnet-0/group_vars/nimbus.yaml
@@ -1,13 +1,8 @@
 # role: ethpandaops.general.bootstrap
-bootstrap_default_user_authorized_keys_github_team_cl:
-  - zah
-  - tersec
-  - etan-status
-  - arnetheduck
-  - chirag-parmar
-  - agnxsh
-  - Tomi-3-0
-  - ahshum
+nimbus_extra_github_users: []  # handles not yet in the coredevs registry
+bootstrap_default_user_authorized_keys_github_team_cl: >-
+  {{ (query('ethpandaops.general.url_cached', coredevs_api_url ~ '/api/v1/users/nimbus?format=txt') | select | list)
+     + nimbus_extra_github_users }}
 
 # role: validator_keys
 validator_keys_sync_files:

--- a/ansible/inventories/devnet-0/group_vars/nimbusel.yaml
+++ b/ansible/inventories/devnet-0/group_vars/nimbusel.yaml
@@ -1,9 +1,8 @@
 # role: ethpandaops.general.bootstrap
-bootstrap_default_user_authorized_keys_github_team_el:
-   - tersec
-   - jangko
-   - advaita-saha
-   - mjfh
+nimbusel_extra_github_users: []  # handles not yet in the coredevs registry
+bootstrap_default_user_authorized_keys_github_team_el: >-
+  {{ (query('ethpandaops.general.url_cached', coredevs_api_url ~ '/api/v1/users/nimbus?format=txt') | select | list)
+     + nimbusel_extra_github_users }}
 
 # role: ethpandaops.general.ethereum_node
 ethereum_node_el: nimbusel

--- a/ansible/inventories/devnet-0/group_vars/prysm.yaml
+++ b/ansible/inventories/devnet-0/group_vars/prysm.yaml
@@ -1,16 +1,9 @@
 # role: ethpandaops.general.bootstrap
-bootstrap_default_user_authorized_keys_github_team_cl:
-  - aarshkshah1992
-  - Inspector-Butters
-  - james-prysm
-  - kasey
-  - nalepae
-  - potuz
-  - prestonvanloon
-  - rkapka
-  - satushh
+prysm_extra_github_users:  # handles not yet in the coredevs registry
   - syjn99
-  - terencechain
+bootstrap_default_user_authorized_keys_github_team_cl: >-
+  {{ (query('ethpandaops.general.url_cached', coredevs_api_url ~ '/api/v1/users/prysm?format=txt') | select | list)
+     + prysm_extra_github_users }}
 
 # role: validator_keys
 validator_keys_sync_files:

--- a/ansible/inventories/devnet-0/group_vars/reth.yaml
+++ b/ansible/inventories/devnet-0/group_vars/reth.yaml
@@ -1,14 +1,8 @@
 # role: ethpandaops.general.bootstrap
-bootstrap_default_user_authorized_keys_github_team_el:
-  - gakonst
-  - onbjerg
-  - klkvr
-  - shekhirin
-  - rkrasiuk
-  - mattsse
-  - jenpaff
-  - emmajam
-  - rjected
+reth_extra_github_users: []  # handles not yet in the coredevs registry
+bootstrap_default_user_authorized_keys_github_team_el: >-
+  {{ (query('ethpandaops.general.url_cached', coredevs_api_url ~ '/api/v1/users/reth?format=txt') | select | list)
+     + reth_extra_github_users }}
 
 # role: ethpandaops.general.ethereum_node
 ethereum_node_el: reth

--- a/ansible/inventories/devnet-0/group_vars/teku.yaml
+++ b/ansible/inventories/devnet-0/group_vars/teku.yaml
@@ -1,12 +1,9 @@
 # role: ethpandaops.general.bootstrap
-bootstrap_default_user_authorized_keys_github_team_cl:
-  - tbenr
-  - rolfyone
+teku_extra_github_users:  # handles not yet in the coredevs registry
   - siladu
-  - lucassaldanha
-  - StefanBratanov
-  - zilm13
-  - mehdi-aouadi
+bootstrap_default_user_authorized_keys_github_team_cl: >-
+  {{ (query('ethpandaops.general.url_cached', coredevs_api_url ~ '/api/v1/users/teku?format=txt') | select | list)
+     + teku_extra_github_users }}
 
 # role: validator_keys
 validator_keys_sync_files:


### PR DESCRIPTION
Replaces the hardcoded per-client `bootstrap_default_user_authorized_keys_github_*` lists in the template group_vars with runtime fetches from the [coredevs](https://github.com/ethpandaops/coredevs) registry (via the `ethpandaops.general.url_cached` lookup already used for the `.keys` fetch), so devnets generated from this template get auto-updating client-dev SSH access; each list keeps a `*_extra_github_users` union for handles not yet in coredevs (prysm `syjn99`, teku `siladu`). The `mev-relay-1` host_var roster has no coredevs analog and is left hardcoded. This is the Terraform scaffold (no live nodes), so it's validated statically — YAML parse + jinja syntax on all 14 templated expressions — while the runtime behaviour is proven on the equivalent live PRs (blob-devnets, bal-devnets, glamsterdam-devnets).