### PR TITLE
feat(el): use ENR bootnodes and run discv5-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,10 @@ curl -s https://bootnode-1.devnet-0.ethpandaops.io/meta/api/v1/validator-ranges.
 ethdo --connection=https://user:password@bn.lighthouse-nethermind-1.devnet-0.ethpandaops.io block info --blockid 100 --json | jq -r .message.proposer_index | ./whose_validator.zsh
 ```
 from the [ansible/](ansible/) directory.
+* Getting execution layer client ENRs
+```shell
+curl -s https://config.devnet-0.ethpandaops.io/api/v1/nodes/inventory | jq -r '.ethereum_pairs[] | .execution.enr'
+```
 * Getting execution layer client enodes
 ```shell
 curl -s https://config.devnet-0.ethpandaops.io/api/v1/nodes/inventory | jq -r '.ethereum_pairs[] | .execution.enode'

--- a/ansible/inventories/devnet-0/group_vars/besu.yaml
+++ b/ansible/inventories/devnet-0/group_vars/besu.yaml
@@ -20,6 +20,7 @@ besu_container_volumes:
 besu_container_command_extra_args:
   - --genesis-file=/network-config/besu.json
   - --bootnodes={{ ethereum_el_bootnodes | join(',') }}
+  - --discovery-mode=V5
   - --rpc-http-api=ADMIN,DEBUG,ETH,MINER,NET,TRACE,TXPOOL,WEB3
   - --sync-mode=FULL
   - --data-storage-format=BONSAI

--- a/ansible/inventories/devnet-0/group_vars/bootnode.yaml
+++ b/ansible/inventories/devnet-0/group_vars/bootnode.yaml
@@ -1,5 +1,5 @@
 ethereum_cl_bootnode: "{{ hostvars[primary_bootnode]['bootnodoor_fact_enr'] }}"
-ethereum_el_bootnode: "{{ hostvars[primary_bootnode]['bootnodoor_fact_enode'] }}"
+ethereum_el_bootnode: "{{ hostvars[primary_bootnode]['bootnodoor_fact_el_enr'] }}"
 
 # role: eth_inventory_web
 eth_inventory_web_container_networks: "{{ docker_networks_shared }}"
@@ -104,19 +104,21 @@ geth_container_command_extra_args:
   - --syncmode=full
   - --gcmode=archive
   - --state.scheme=hash
+  - --discovery.v4=false
+  - --discovery.v5=true
   - >-
     --bootnodes={{
       (
         (
           groups['bootnode']
-          | map('extract', hostvars, ['ethereum_node_fact_discovery_el_enode'])
+          | map('extract', hostvars, ['ethereum_node_fact_discovery_el_enr'])
           | select('defined')
           | list
         )
         +
         (
           groups['bootnode']
-          | map('extract', hostvars, ['bootnodoor_fact_enode'])
+          | map('extract', hostvars, ['bootnodoor_fact_el_enr'])
           | select('defined')
           | list
         )

--- a/ansible/inventories/devnet-0/group_vars/erigon.yaml
+++ b/ansible/inventories/devnet-0/group_vars/erigon.yaml
@@ -21,6 +21,8 @@ erigon_container_command_extra_args:
   - --networkid={{ ethereum_network_id }}
   - --db.size.limit=500GB
   - --bootnodes={{ ethereum_el_bootnodes | join(',') }}
+  - --discovery.v4=false
+  - --discovery.v5=true
 erigon_init_custom_network: true
 erigon_init_custom_network_genesis_file: "{{ eth_testnet_config_dir }}/genesis.json"
 

--- a/ansible/inventories/devnet-0/group_vars/ethereum_node.yaml
+++ b/ansible/inventories/devnet-0/group_vars/ethereum_node.yaml
@@ -3,8 +3,8 @@ ethereum_cl_bootnodes:
   - "{{ hostvars[primary_bootnode]['ethereum_node_fact_discovery_cl_enr'] }}"
 
 ethereum_el_bootnodes:
-  - "{{ hostvars[primary_bootnode]['bootnodoor_fact_enode'] }}"
-  - "{{ hostvars[primary_bootnode]['ethereum_node_fact_discovery_el_enode'] }}"
+  - "{{ hostvars[primary_bootnode]['bootnodoor_fact_el_enr'] }}"
+  - "{{ hostvars[primary_bootnode]['ethereum_node_fact_discovery_el_enr'] }}"
 
 ethereum_node_xatu_sentry_enabled: true
 

--- a/ansible/inventories/devnet-0/group_vars/ethrex.yaml
+++ b/ansible/inventories/devnet-0/group_vars/ethrex.yaml
@@ -21,6 +21,8 @@ ethrex_container_volumes:
 ethrex_container_command_extra_args:
   - --network=/network-config/genesis.json
   - --bootnodes={{ ethereum_el_bootnodes | join(',') }}
+  - --p2p.discv4=false
+  - --p2p.discv5=true
   - --http.api=eth,net,web3,admin,debug,txpool
 
 prometheus_config: |

--- a/ansible/inventories/devnet-0/group_vars/geth.yaml
+++ b/ansible/inventories/devnet-0/group_vars/geth.yaml
@@ -25,6 +25,8 @@ geth_container_command_extra_args:
   - --networkid={{ ethereum_network_id }}
   - --syncmode=full
   - --bootnodes={{ ethereum_el_bootnodes | join(',') }}
+  - --discovery.v4=false
+  - --discovery.v5=true
 
 geth_container_pull: true
 

--- a/ansible/inventories/devnet-0/group_vars/nethermind.yaml
+++ b/ansible/inventories/devnet-0/group_vars/nethermind.yaml
@@ -23,6 +23,7 @@ nethermind_container_command_extra_args:
   - --Init.ChainSpecPath=/network-config/chainspec.json
   - --JsonRpc.EnabledModules=Eth,Subscribe,Trace,TxPool,Web3,Personal,Proof,Net,Parity,Health,Rpc,Debug,Admin
   - --Discovery.Bootnodes={{ ethereum_el_bootnodes | join(',') }}
+  - --Discovery.DiscoveryVersion=V5
   - --Pruning.Mode=None
   - --config=none
   - --log=DEBUG

--- a/ansible/inventories/devnet-0/group_vars/reth.yaml
+++ b/ansible/inventories/devnet-0/group_vars/reth.yaml
@@ -21,6 +21,7 @@ reth_container_volumes:
 reth_container_command_extra_args:
   - --chain=/network-config/genesis.json
   - --bootnodes={{ ethereum_el_bootnodes | join(',') }}
+  - --disable-discv4-discovery
   - --http.api=trace,rpc,eth,net,debug,web3,admin,txpool
 prometheus_config: |
   global:

--- a/ansible/inventories/devnet-0/host_vars/mev-relay-1.yaml
+++ b/ansible/inventories/devnet-0/host_vars/mev-relay-1.yaml
@@ -138,7 +138,7 @@ lighthouse_validator_datadir: /data/lighthouse-validator
 lighthouse_container_pull: true
 
 ethereum_el_bootnodes:
-  - "{{ hostvars[primary_bootnode]['ethereum_node_fact_discovery_el_enode'] }}"
+  - "{{ hostvars[primary_bootnode]['ethereum_node_fact_discovery_el_enr'] }}"
 
 ethereum_cl_bootnodes:
   - "{{ hostvars[primary_bootnode]['ethereum_node_fact_discovery_cl_enr'] }}"
@@ -159,6 +159,7 @@ reth_container_env:
 reth_container_command_extra_args:
   - --chain=/network-config/genesis.json
   - --bootnodes={{ ethereum_el_bootnodes | join(',') }}
+  - --disable-discv4-discovery
   - --http.api=trace,rpc,eth,net,debug,web3,admin,flashbots,txpool
   - --ws.api=trace,rpc,eth,net,debug,web3,admin,flashbots,txpool
   - --ws.origins=*


### PR DESCRIPTION
## Why

Execution clients are moving to discv5-only for devnet-8, and discv5 bootstraps from **ENRs**, not enodes:

- **besu** swaps its bootnode list to ENR-only the moment discv5 is enabled and rejects enodes with `Invalid ENR bootnode: ... must start with 'enr:'`.
- **nimbus-eth1** now hard-disables discv4 ([status-im/nimbus-eth1#4582](https://github.com/status-im/nimbus-eth1/pull/4582), merged), so the enodes it receives feed a protocol that no longer runs.

## What

Swap both EL bootnode sources to their ENR equivalents:

| before | after |
|---|---|
| `ethereum_node_fact_discovery_el_enode` | `ethereum_node_fact_discovery_el_enr` |
| `bootnodoor_fact_enode` | `bootnodoor_fact_el_enr` |

covering `ethereum_el_bootnodes`, `ethereum_el_bootnode`, the geth bootnode's own `--bootnodes` list, and the mev-relay reth node.

Then turn discv4 off on every EL that supports the switch:

| client | flag |
|---|---|
| geth | `--discovery.v4=false --discovery.v5=true` |
| erigon | `--discovery.v4=false --discovery.v5=true` |
| ethrex | `--p2p.discv4=false --p2p.discv5=true` |
| reth | `--disable-discv4-discovery` |
| nethermind | `--Discovery.DiscoveryVersion=V5` |
| besu | `--discovery-mode=V5` |
| nimbusel | none needed — discv4 disabled upstream |

The bootnode list has to be all-ENR rather than mixed: besu discards the enode list entirely in discv5 mode, so leaving one enode in would strand it.

## Depends on

[ethpandaops/ansible-collection-general#568](https://github.com/ethpandaops/ansible-collection-general/pull/568) — provides both new facts. `bootnodoor_fact_el_enr` reads bootnodoor's existing `/el-enr` endpoint; `ethereum_node_fact_discovery_el_enr` derives the ENR from the node key via `devp2p key to-enr`.

## Note on besu

`--discovery-mode` is on besu main only ([#10800](https://github.com/hyperledger/besu/pull/10800), unreleased). Verified empirically: `hyperledger/besu:latest` (26.7.0) leaves `--discovery-mode=V5` unmatched and accepts the older `--Xv5-discovery-enabled=true`, while `ethpandaops/besu:main` is the exact inverse. The two are mutually exclusive, so besu nodes need a main-based build.

## Testing

`ansible-lint` reports an identical 77 failures / 3 warnings across 37 files before and after this change — all pre-existing formatting noise, nothing new introduced.